### PR TITLE
Use quoted header import style for dependencies in CocoaPods usage

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "1.6.3"
+  s.version = "1.6.4"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/Sources/AuthedJsonHttpClient.h
+++ b/Sources/AuthedJsonHttpClient.h
@@ -6,7 +6,12 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#ifdef COCOAPODS
+#import "AFNetworking.h"
+#else
 #import <AFNetworking/AFNetworking.h>
+#endif
 
 @interface AuthedJsonHttpClient : AFHTTPSessionManager
 

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.3</string>
+	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.3</string>
+	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Crash.m
+++ b/Sources/Kumulos+Crash.m
@@ -7,7 +7,12 @@
 //
 
 #import "Kumulos+Crash.h"
+
+#ifdef COCOAPODS
+#import "KSCrash.h"
+#else
 #import <KSCrash/KSCrash.h>
+#endif
 
 @implementation Kumulos (Crash)
 

--- a/Sources/Kumulos+Protected.h
+++ b/Sources/Kumulos+Protected.h
@@ -5,7 +5,12 @@
 //  Copyright © 2016 kumulos. All rights reserved.
 //
 
+#ifdef COCOAPODS
+#import "AFNetworking.h"
+#else
 #import <AFNetworking/AFNetworking.h>
+#endif
+
 #import "Kumulos.h"
 #import "RpcHttpClient.h"
 #import "AuthedJsonHttpClient.h"

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -15,8 +15,13 @@
 #import "Kumulos+Push.h"
 #endif
 
+#ifdef COCOAPODS
+#import "KSCrash.h"
+#import "KSCrashInstallationStandard.h"
+#else
 #import <KSCrash/KSCrash.h>
 #import <KSCrash/KSCrashInstallationStandard.h>
+#endif
 
 static NSString * const KSStatsBaseUrl = @"https://stats.kumulos.com";
 static NSString * const KSPushBaseUrl = @"https://push.kumulos.com";

--- a/Sources/RpcHttpClient.h
+++ b/Sources/RpcHttpClient.h
@@ -6,7 +6,12 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#ifdef COCOAPODS
+#import "AFNetworking.h"
+#else
 #import <AFNetworking/AFNetworking.h>
+#endif
 
 @interface RpcHttpClient : AFHTTPSessionManager
 


### PR DESCRIPTION
Works around an issue with Cordova plugin usage from a pod where headers can't be resolved using the system style imports. See https://issues.apache.org/jira/browse/CB-14057.