### PR TITLE
Add configurable push received in foreground handler

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.0.0"
+  s.version = "2.1.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 2.0'
+pod 'KumulosSdkObjectiveC', '~> 2.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 2.0
+github "Kumulos/KumulosSdkObjectiveC" ~> 2.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/KSUserNotificationCenterDelegate.m
+++ b/Sources/KSUserNotificationCenterDelegate.m
@@ -24,7 +24,12 @@
 
 // Called on iOS10+ when your app is in the foreground to allow customizing the display of the notification
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-    completionHandler(UNNotificationPresentationOptionAlert);
+    if (self.kumulos.config.pushReceivedInForegroundHandler) {
+        KSPushNotification* push = [KSPushNotification fromUserInfo:notification.request.content.userInfo];
+        self.kumulos.config.pushReceivedInForegroundHandler(push, completionHandler);
+    } else {
+        completionHandler(UNNotificationPresentationOptionAlert);
+    }
 }
 
 // iOS10+ handler for when a user taps a notification

--- a/Sources/Kumulos+Push.h
+++ b/Sources/Kumulos+Push.h
@@ -10,6 +10,8 @@
 
 @interface KSPushNotification : NSObject
 
++ (instancetype _Nonnull) fromUserInfo:(NSDictionary* _Nonnull)userInfo;
+
 @property (nonatomic,readonly) NSNumber* _Nonnull id;
 @property (nonatomic,readonly) NSDictionary* _Nonnull aps;
 @property (nonatomic,readonly) NSDictionary* _Nonnull data;

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
 
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 #else
@@ -21,6 +22,11 @@ typedef void (^ _Nullable KSAPIOperationSuccessBlock)(KSAPIResponse* _Nonnull, K
 typedef void (^ _Nullable KSAPIOperationFailureBlock)(NSError* _Nonnull, KSAPIOperation* _Nonnull);
 typedef void (^ _Nullable KSInAppDeepLinkHandlerBlock)(NSDictionary* _Nonnull data);
 typedef void (^ _Nullable KSPushOpenedHandlerBlock)(KSPushNotification* _Nonnull notification);
+
+API_AVAILABLE(ios(10.0), macos(10.14))
+typedef void (^ _Nonnull KSPushReceivedInForegroundCompletionHandler)(UNNotificationPresentationOptions);
+API_AVAILABLE(ios(10.0), macos(10.14))
+typedef void (^ _Nullable KSPushReceivedInForegroundHandlerBlock)(KSPushNotification* _Nonnull notification, KSPushReceivedInForegroundCompletionHandler completionHandler);
 
 /**
  * Config options for initializing a Kumulos instance
@@ -52,6 +58,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 @property (nonatomic,readonly) KSInAppConsentStrategy inAppConsentStrategy;
 @property (nonatomic,readonly) KSInAppDeepLinkHandlerBlock inAppDeepLinkHandler;
 @property (nonatomic,readonly) KSPushOpenedHandlerBlock pushOpenedHandler;
+@property (nonatomic,readonly) KSPushReceivedInForegroundHandlerBlock pushReceivedInForegroundHandler API_AVAILABLE(ios(10.0), macos(10.14));
 
 + (instancetype _Nullable) configWithAPIKey:(NSString* _Nonnull)APIKey andSecretKey:(NSString* _Nonnull)secretKey;
 
@@ -62,6 +69,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 - (instancetype _Nonnull) enableInAppMessaging:(KSInAppConsentStrategy)consentStrategy;
 - (instancetype _Nonnull) setInAppDeepLinkHandler:(KSInAppDeepLinkHandlerBlock)deepLinkHandler;
 - (instancetype _Nonnull) setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler;
+- (instancetype _Nonnull) setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler API_AVAILABLE(ios(10.0),macos(10.14));
 #endif
 
 - (instancetype _Nonnull) setSessionIdleTimeout:(NSUInteger)timeoutSeconds;

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -49,6 +49,7 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
         self->_inAppConsentStrategy = KSInAppConsentStrategyNotEnabled;
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
+        self->_pushReceivedInForegroundHandler = nil;
     }
     return self;
 }
@@ -70,6 +71,11 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
 
 - (instancetype)setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler {
     self->_pushOpenedHandler = notificationHandler;
+    return self;
+}
+
+- (instancetype)setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler  API_AVAILABLE(macos(10.14)){
+    self->_pushReceivedInForegroundHandler = receivedHandler;
     return self;
 }
 


### PR DESCRIPTION
Allows customisation of presentation / handling of pushes received whilst the app is active.