### PR TITLE
Add constant for base SDK version

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.1.0"
+  s.version = "2.1.1"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,6 +15,8 @@
 #import "KumulosEvents.h"
 #endif
 
+static const NSString* KSSdkVersion = @"2.1.1";
+
 @implementation Kumulos (Stats)
 
 - (void) statsSendInstallInfo {
@@ -45,11 +47,8 @@
     NSDictionary *sdk = self.config.sdkInfo;
     
     if (nil == sdk) {
-        NSBundle* frameworkBundle = [NSBundle bundleForClass:[self class]];
-        NSString* frameworkVersion = [[frameworkBundle infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-        
         sdk = @{@"id" : @(SDKTypeObjC),
-                @"version" : frameworkVersion};
+                @"version" : KSSdkVersion};
     }
     
     NSDictionary *runtime = self.config.runtimeInfo;


### PR DESCRIPTION
To fix issues with some CocoaPods setups that report the SDK version as app version, we have moved the version to a const in SDK sources.