### PR TITLE
Minor in-app fixes

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.2.0"
+  s.version = "2.2.1"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/Sources/InApp/KSInAppHelper.m
+++ b/Sources/InApp/KSInAppHelper.m
@@ -491,16 +491,12 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
         return;
     }
 
-    BOOL isActive = UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
-
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSNumber* inAppPartId = notification.inAppDeepLink[@"data"][@"id"];
         @synchronized (self.pendingTickleIds) {
             [self.pendingTickleIds addObject:inAppPartId];
-            if (isActive) {
-                NSArray<KSInAppMessage*>* messages = [self getMessagesToPresent:@[]];
-                [self.presenter queueMessagesForPresentation:messages presentingTickles:self.pendingTickleIds];
-            }
+            NSArray<KSInAppMessage*>* messages = [self getMessagesToPresent:@[]];
+            [self.presenter queueMessagesForPresentation:messages presentingTickles:self.pendingTickleIds];
         }
     });
 }

--- a/Sources/InApp/KSInAppPresenter.m
+++ b/Sources/InApp/KSInAppPresenter.m
@@ -166,7 +166,7 @@ NSString* const _Nonnull KSInAppActionRequestRating = @"requestAppStoreRating";
 
 #ifdef __IPHONE_13_0
     if (@available(iOS 13, *)) {
-        self.window.windowScene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+        self.window.windowScene = (UIWindowScene*)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
     }
 #endif
 

--- a/Sources/InApp/KSInAppPresenter.m
+++ b/Sources/InApp/KSInAppPresenter.m
@@ -121,6 +121,13 @@ NSString* const _Nonnull KSInAppActionRequestRating = @"requestAppStoreRating";
 }
 
 - (void) handleMessageClosed {
+    if (@available(iOS 10, *)) {
+        if (self.currentMessage) {
+            NSString* tickleNotificationId = [NSString stringWithFormat:@"k-in-app-message:%@", self.currentMessage.id];
+            [UNUserNotificationCenter.currentNotificationCenter removeDeliveredNotificationsWithIdentifiers:@[tickleNotificationId]];
+        }
+    }
+
     @synchronized (self.messageQueue) {
         [self.messageQueue removeObjectAtIndex:0];
         [self.pendingTickleIds removeObject:self.currentMessage.id];
@@ -132,11 +139,6 @@ NSString* const _Nonnull KSInAppActionRequestRating = @"requestAppStoreRating";
         } else {
             [self presentFromQueue];
         }
-    }
-
-    if (@available(iOS 10, *)) {
-        NSString* tickleNotificationId = [NSString stringWithFormat:@"k-in-app-message:%@", self.currentMessage.id];
-        [UNUserNotificationCenter.currentNotificationCenter removeDeliveredNotificationsWithIdentifiers:@[tickleNotificationId]];
     }
 }
 

--- a/Sources/InApp/KSInAppPresenter.m
+++ b/Sources/InApp/KSInAppPresenter.m
@@ -218,12 +218,9 @@ NSString* const _Nonnull KSInAppActionRequestRating = @"requestAppStoreRating";
     self.loadingSpinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
     self.loadingSpinner.translatesAutoresizingMaskIntoConstraints = NO;
     self.loadingSpinner.hidesWhenStopped = YES;
+    self.loadingSpinner.center = self.frame.center;
     [self.loadingSpinner startAnimating];
     [self.frame addSubview:self.loadingSpinner];
-
-    NSLayoutConstraint* horCon = [NSLayoutConstraint constraintWithItem:self.loadingSpinner attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self.frame attribute:NSLayoutAttributeCenterX multiplier:1 constant:0];
-    NSLayoutConstraint* verCon = [NSLayoutConstraint constraintWithItem:self.loadingSpinner attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.frame attribute:NSLayoutAttributeCenterY multiplier:1 constant:0];
-    [self.frame addConstraints:@[horCon, verCon]];
 
     [self.frame bringSubviewToFront:self.loadingSpinner];
 }

--- a/Sources/InApp/KSInAppPresenter.m
+++ b/Sources/InApp/KSInAppPresenter.m
@@ -164,6 +164,12 @@ NSString* const _Nonnull KSInAppActionRequestRating = @"requestAppStoreRating";
     self.window.windowLevel = UIWindowLevelAlert;
     [self.window setRootViewController:[UIViewController new]];
 
+#ifdef __IPHONE_13_0
+    if (@available(iOS 13, *)) {
+        self.window.windowScene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    }
+#endif
+
     self.frame = [[UIView alloc] initWithFrame:self.window.frame];
     self.frame.backgroundColor = UIColor.clearColor;
     [self.window.rootViewController setView:self.frame];

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"2.2.0";
+static const NSString* KSSdkVersion = @"2.2.1";
 
 @implementation Kumulos (Stats)
 


### PR DESCRIPTION
### Description of Changes

- Clear in-app push from tray prior to clearing currentMessage state
- Remove spinner constraints to fix warnings/simplify code
- Remove isActive guard in handling in-app deep link from push open
-  Connect the in-app UIWindow to the current scene if on iOS13

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes
-   [x] Verify conditional compilation & functionality in iOS13 UIScene app in Xcode 11

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
