### PR TITLE
Config setting for foreground push presentation

### DIFF
--- a/Sources/KSUserNotificationCenterDelegate.m
+++ b/Sources/KSUserNotificationCenterDelegate.m
@@ -31,7 +31,6 @@ API_AVAILABLE(ios(10.0))
 
 // Called on iOS10+ when your app is in the foreground to allow customizing the display of the notification
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-    
     NSDictionary* userInfo = notification.request.content.userInfo;
     KSPushNotification* push = [KSPushNotification fromUserInfo:userInfo];
 
@@ -44,7 +43,7 @@ API_AVAILABLE(ios(10.0))
         KSPushNotification* push = [KSPushNotification fromUserInfo:notification.request.content.userInfo];
         self.kumulos.config.pushReceivedInForegroundHandler(push);
     }
-    
+
     completionHandler(self.kumulos.config.foregroundPushPresentationOptions);
 }
 

--- a/Sources/KSUserNotificationCenterDelegate.m
+++ b/Sources/KSUserNotificationCenterDelegate.m
@@ -29,7 +29,7 @@
         self.kumulos.config.pushReceivedInForegroundHandler(push);
     }
     
-    completionHandler(self.kumulos.config.foregroundPushPresentationOption);
+    completionHandler(self.kumulos.config.foregroundPushPresentationOptions);
 }
 
 // iOS10+ handler for when a user taps a notification

--- a/Sources/KSUserNotificationCenterDelegate.m
+++ b/Sources/KSUserNotificationCenterDelegate.m
@@ -26,10 +26,10 @@
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
     if (self.kumulos.config.pushReceivedInForegroundHandler) {
         KSPushNotification* push = [KSPushNotification fromUserInfo:notification.request.content.userInfo];
-        self.kumulos.config.pushReceivedInForegroundHandler(push, completionHandler);
-    } else {
-        completionHandler(UNNotificationPresentationOptionAlert);
+        self.kumulos.config.pushReceivedInForegroundHandler(push);
     }
+    
+    completionHandler(self.kumulos.config.foregroundPushPresentationOption);
 }
 
 // iOS10+ handler for when a user taps a notification

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 @property (nonatomic,readonly) NSDictionary* _Nullable runtimeInfo;
 @property (nonatomic,readonly) NSDictionary* _Nullable sdkInfo;
 @property (nonatomic,readonly) KSTargetType targetType;
-@property (nonatomic,readonly) UNNotificationPresentationOptions foregroundPushPresentationOption API_AVAILABLE(ios(10.0), macos(10.14));;
+@property (nonatomic,readonly) UNNotificationPresentationOptions foregroundPushPresentationOptions API_AVAILABLE(ios(10.0), macos(10.14));;
 
 @property (nonatomic,readonly) KSInAppConsentStrategy inAppConsentStrategy;
 @property (nonatomic,readonly) KSInAppDeepLinkHandlerBlock inAppDeepLinkHandler;
@@ -71,6 +71,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 - (instancetype _Nonnull) setInAppDeepLinkHandler:(KSInAppDeepLinkHandlerBlock)deepLinkHandler;
 - (instancetype _Nonnull) setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler;
 - (instancetype _Nonnull) setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler API_AVAILABLE(ios(10.0),macos(10.14));
+- (instancetype _Nonnull) setForegroundPushPresentationOptions:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14));
 #endif
 
 - (instancetype _Nonnull) setSessionIdleTimeout:(NSUInteger)timeoutSeconds;

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -26,7 +26,7 @@ typedef void (^ _Nullable KSPushOpenedHandlerBlock)(KSPushNotification* _Nonnull
 API_AVAILABLE(ios(10.0), macos(10.14))
 typedef void (^ _Nonnull KSPushReceivedInForegroundCompletionHandler)(UNNotificationPresentationOptions);
 API_AVAILABLE(ios(10.0), macos(10.14))
-typedef void (^ _Nullable KSPushReceivedInForegroundHandlerBlock)(KSPushNotification* _Nonnull notification, KSPushReceivedInForegroundCompletionHandler completionHandler);
+typedef void (^ _Nullable KSPushReceivedInForegroundHandlerBlock)(KSPushNotification* _Nonnull notification);
 
 /**
  * Config options for initializing a Kumulos instance
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 @property (nonatomic,readonly) NSDictionary* _Nullable runtimeInfo;
 @property (nonatomic,readonly) NSDictionary* _Nullable sdkInfo;
 @property (nonatomic,readonly) KSTargetType targetType;
+@property (nonatomic,readonly) UNNotificationPresentationOptions foregroundPushPresentationOption API_AVAILABLE(ios(10.0), macos(10.14));;
 
 @property (nonatomic,readonly) KSInAppConsentStrategy inAppConsentStrategy;
 @property (nonatomic,readonly) KSInAppDeepLinkHandlerBlock inAppDeepLinkHandler;

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -50,7 +50,10 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
         self->_pushReceivedInForegroundHandler = nil;
-        self->_foregroundPushPresentationOptions = UNNotificationPresentationOptionAlert;
+        
+        if (@available(iOS 10, *)) {
+            self->_foregroundPushPresentationOptions = UNNotificationPresentationOptionAlert;
+        }
     }
     return self;
 }

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -75,8 +75,8 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
     return self;
 }
 
-- (instancetype)setForegroundPushPresentationOption:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14)) {
-    self->_foregroundPushPresentationOptions =notificationPresentationOptions;
+- (instancetype)setForegroundPushPresentationOptions:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14)) {
+    self->_foregroundPushPresentationOptions = notificationPresentationOptions;
     return self;
 }
 

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -50,6 +50,7 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
         self->_pushReceivedInForegroundHandler = nil;
+        self->_foregroundPushPresentationOption = UNNotificationPresentationOptionAlert;
     }
     return self;
 }

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -50,7 +50,7 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
         self->_pushReceivedInForegroundHandler = nil;
-        self->_foregroundPushPresentationOption = UNNotificationPresentationOptionAlert;
+        self->_foregroundPushPresentationOptions = UNNotificationPresentationOptionAlert;
     }
     return self;
 }
@@ -75,7 +75,12 @@ static NSString * const KSEventsBaseUrl = @"https://events.kumulos.com";
     return self;
 }
 
-- (instancetype)setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler  API_AVAILABLE(macos(10.14)){
+- (instancetype)setForegroundPushPresentationOption:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14)) {
+    self->_foregroundPushPresentationOptions =notificationPresentationOptions;
+    return self;
+}
+
+- (instancetype)setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler API_AVAILABLE(macos(10.14)){
     self->_pushReceivedInForegroundHandler = receivedHandler;
     return self;
 }


### PR DESCRIPTION
### Description of Changes

Due to the Xamarin SDK depending on this SDK for native bindings and limitations of the JIT->AOT compilation for iOS code we are encountering runtime exceptions in Xamarin apps that make use of the pushReceivedInForegroundHandler.

In its current implementation the SDK gives the provided handler a reference back to the completionHandler method to be called from the managed code layer, this creates the runtime exception.

Related documentation: https://docs.microsoft.com/en-gb/xamarin/ios/internals/limitations#using-delegates-to-call-native-functions

### Breaking Changes

- `setPushReceivedInForegroundHandler` will be called with only 1 parameter (the notification)
- `setForegroundPushPresentationOptions` on configuration, allows consumers to set the behaviour for presentation of notifications received while app is in foreground, defaults to `Alert`

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

~~Bump versions in:~~ Hold for buttons release

-   [ ] `Sources/Kumulos+Stats.m`
-   [ ] `KumulosSdkObjectiveC.podspec`
-   [ ] `Sources/Info-*.plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] ~~Create tag from master matching chosen version~~
-   [ ] ~~Run `pod trunk push` to publish to CocoaPods~~
