### PR TITLE
Support pictures in push notifications

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.2.1"
+  s.version = "2.3.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 2.2'
+pod 'KumulosSdkObjectiveC', '~> 2.3'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,17 +33,17 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 2.2
+github "Kumulos/KumulosSdkObjectiveC" ~> 2.3
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
 
 Please also ensure you link your project against:
 
--   SystemConfiguration.framework
--   MessageUI.framework (for iOS projects)
--   libc++
--   libz
+- SystemConfiguration.framework
+- MessageUI.framework (for iOS projects)
+- libc++
+- libz
 
 After installation, you can now import & initialize the SDK with:
 
@@ -68,4 +68,4 @@ This project is licensed under the MIT license with portions licensed under the 
 
 ## Requirements
 
--   iOS8+
+- iOS8+

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Push.h
+++ b/Sources/Kumulos+Push.h
@@ -24,7 +24,7 @@
 
 /**
  * Requests a push token from the user.
- * 
+ *
  * Will prompt for alert, sound, and badge permissions.
  *
  * After the permission is granted, you should call Kumulos#pushRegisterWithDeviceToken to complete the registration flow.
@@ -47,5 +47,12 @@
  * @param notification The remote notification model that was receieved by the device
  */
 - (void) pushTrackOpenFromNotification:(KSPushNotification* _Nullable)notification;
+
+/**
+* Implementation of Notification Service Extension. Handles display of pictures in notifications
+* @param request  from Notification Service Extension
+* @param contentHandler from Notification Service Extension
+*/
++ (void) didReceiveNotificationRequest:(UNNotificationRequest * _Nonnull)request withContentHandler:(void (^_Nonnull)(UNNotificationContent * _Nonnull))contentHandler API_AVAILABLE(ios(10.0));
 
 @end

--- a/Sources/Kumulos+Push.m
+++ b/Sources/Kumulos+Push.m
@@ -192,7 +192,7 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
     return [token copy];
 }
 
-// KUMULOS NOTIFICATION SERVICE EXTENSION
+#pragma mark - Notification service extension
 
 + (void) didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
     
@@ -233,7 +233,7 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
         return [NSURL URLWithString:pictureUrl];
     }
 
-    CGFloat width = ([UIScreen mainScreen].bounds.size.width);
+    CGFloat width = UIScreen.mainScreen.bounds.size.width;
     NSInteger num = (NSInteger) (floor(width));
 
     NSString *completeString = [NSString stringWithFormat:@"%@%@%ld%@%@", KSMediaResizerBaseUrl, @"/", (long) num, @"x/", pictureUrl];

--- a/Sources/Kumulos+Push.m
+++ b/Sources/Kumulos+Push.m
@@ -22,6 +22,8 @@ static IMP ks_existingPushRegisterDelegate = NULL;
 static IMP ks_existingPushRegisterFailDelegate = NULL;
 static IMP ks_existingPushReceiveDelegate = NULL;
 
+NSString* const _Nonnull KSMediaResizerBaseUrl = @"https://i.app.delivery";
+
 typedef void (^KSCompletionHandler)(UIBackgroundFetchResult);
 void kumulos_applicationDidRegisterForRemoteNotifications(id self, SEL _cmd, UIApplication* application, NSData* deviceToken);
 void kumulos_applicationDidFailToRegisterForRemoteNotifications(id self, SEL _cmd, UIApplication* application, NSError* error);
@@ -188,6 +190,78 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
     }
     
     return [token copy];
+}
+
+// KUMULOS NOTIFICATION SERVICE EXTENSION
+
++ (void) didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
+    
+    UNMutableNotificationContent *bestAttemptContent = [request.content mutableCopy];
+
+    NSDictionary *userInfo = request.content.userInfo;
+    NSDictionary *attachments = userInfo == nil ? nil : userInfo[@"attachments"];
+    NSString *pictureUrl = attachments == nil ? nil : attachments[@"pictureUrl"];
+
+    if (pictureUrl == nil) {
+        contentHandler(bestAttemptContent);
+        return;
+    }
+
+    NSString *extension = [self getPictureExtension: pictureUrl];
+    NSURL *url = [self getCompletePictureUrl: pictureUrl];
+    [self loadAttachment:url withExtension:extension
+                   completionHandler:^(UNNotificationAttachment *attachment) {
+                       if (attachment) {
+                           bestAttemptContent.attachments = [NSArray arrayWithObject:attachment];
+                       }
+                       contentHandler(bestAttemptContent);
+                   }];
+}
+
++ (NSString *) getPictureExtension:(NSString *) pictureUrl {
+    NSString *pictureExtension = [pictureUrl pathExtension];
+    if ([pictureExtension isEqualToString:@""]){
+       pictureExtension = @"jpg";
+    }
+    return [ @"." stringByAppendingString:pictureExtension];
+}
+
++ (NSURL *) getCompletePictureUrl:(NSString *)pictureUrl {
+    if ([[pictureUrl substringWithRange:NSMakeRange(0, 8)] isEqualToString:@"https://"]
+        || [[pictureUrl substringWithRange:NSMakeRange(0, 7)] isEqualToString:@"http://"]){
+        return [NSURL URLWithString:pictureUrl];
+    }
+
+    CGFloat width = ([UIScreen mainScreen].bounds.size.width);
+    NSInteger num = (NSInteger) (floor(width));
+
+    NSString *completeString = [NSString stringWithFormat:@"%@%@%ld%@%@", KSMediaResizerBaseUrl, @"/", (long) num, @"x/", pictureUrl];
+    return [NSURL URLWithString:completeString];
+}
+
++ (void)loadAttachment:(NSURL *)url withExtension:(NSString *)pictureExtension completionHandler:(void(^)(UNNotificationAttachment *))completionHandler API_AVAILABLE(ios(10.0)){
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+
+    [[session downloadTaskWithURL:url
+                completionHandler:^(NSURL *temporaryFileLocation, NSURLResponse *response, NSError *error) {
+                    if (error != nil) {
+                        NSLog(@"NotificationServiceExtension: %@", error.localizedDescription);
+                        completionHandler(nil);
+                        return;
+                    }
+
+                    NSFileManager *fileManager = [NSFileManager defaultManager];
+                    NSURL *localURL = [NSURL fileURLWithPath:[temporaryFileLocation.path stringByAppendingString:pictureExtension]];
+                    [fileManager moveItemAtURL:temporaryFileLocation toURL:localURL error:&error];
+
+                    NSError *attachmentError = nil;
+                    UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"" URL:localURL options:nil error:&attachmentError];
+                    if (attachmentError) {
+                        NSLog(@"NotificationServiceExtension: attachment error: %@", attachmentError.localizedDescription);
+                    }
+
+                    completionHandler(attachment);
+                }] resume];
 }
 
 @end

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"2.2.1";
+static const NSString* KSSdkVersion = @"2.3.0";
 
 @implementation Kumulos (Stats)
 


### PR DESCRIPTION
### Description of Changes

Add Notification Service Extension to support pictures in push notifications. Implementation of the extension is added to Kumulos + Push. Users have to perform following steps to enable the functionality:

1) add Notification Service Extension to an application
2)  replace contents of `didReceiveNotificationRequest` with `[Kumulos didReceiveNotificationRequest:request withContentHandler: contentHandler];`
3) Make sure Notification Service's deployment target matches test device

Works on ios 10+, notifications expand only on devices that have 3D Touch

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [x] Squash and merge to master
-   [x] Delete branch once merged
-   [x] Create tag from master matching chosen version
-   [x] Run `pod trunk push` to publish to CocoaPods
