### PR TITLE
Message expiry

### DIFF
--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.3.0"
+  s.version = "2.4.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 2.3'
+pod 'KumulosSdkObjectiveC', '~> 2.4'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 2.3
+github "Kumulos/KumulosSdkObjectiveC" ~> 2.4
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/KSInAppHelper.m
+++ b/Sources/InApp/KSInAppHelper.m
@@ -535,7 +535,7 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
     messageEntity.name = @"Message";
     messageEntity.managedObjectClassName = NSStringFromClass(KSInAppMessageEntity.class);
 
-    NSMutableArray<NSAttributeDescription*>* messageProps = [NSMutableArray arrayWithCapacity:10];
+    NSMutableArray<NSAttributeDescription*>* messageProps = [NSMutableArray arrayWithCapacity:11];
 
     NSAttributeDescription* partId = [NSAttributeDescription new];
     partId.name = @"id";

--- a/Sources/InApp/KSInAppHelper.m
+++ b/Sources/InApp/KSInAppHelper.m
@@ -306,6 +306,8 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
                 model.inboxFrom = ![inbox[@"from"] isEqual:NSNull.null] ? [dateParser dateFromString:inbox[@"from"]] : nil;
                 model.inboxTo = ![inbox[@"to"] isEqual:NSNull.null] ? [dateParser dateFromString:inbox[@"to"]] : nil;
             }
+            
+            model.expiresAt =  ![message[@"expiresAt"] isEqual:NSNull.null] ? [dateParser dateFromString:message[@"expiresAt"]] : nil;
 
             if ([model.updatedAt timeIntervalSince1970] > [lastSyncTime timeIntervalSince1970]) {
                 lastSyncTime = model.updatedAt;
@@ -333,10 +335,14 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
 - (void) evictMessages:(NSManagedObjectContext* _Nonnull)context {
     NSFetchRequest* fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Message"];
     [fetchRequest setIncludesPendingChanges:YES];
-
+    
     NSPredicate* predicate = [NSPredicate
-                              predicateWithFormat:@"(dismissedAt != %@ AND inboxConfig = %@) OR (inboxTo != %@ AND inboxTo < %@)",
-                              nil, nil, nil, [NSDate date]];
+                              predicateWithFormat:@"(inboxConfig = nil AND dismissedAt != nil) \
+                              OR \
+                              (inboxConfig = nil AND (expiresAt != nil AND expiresAt <= %@)) \
+                              OR \
+                              (inboxTo != nil AND inboxTo < %@ AND (dismissedAt != nil OR (expiresAt != nil AND expiresAt <= %@)))",
+                              [NSDate date], [NSDate date], [NSDate date]];
     [fetchRequest setPredicate:predicate];
 
     NSError* err = nil;
@@ -363,11 +369,12 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
         [fetchRequest setEntity:entity];
         [fetchRequest setIncludesPendingChanges:NO];
         [fetchRequest setReturnsObjectsAsFaults:NO];
+        
         NSPredicate* predicate = [NSPredicate
-                                  predicateWithFormat:@"((presentedWhen IN %@) OR (id IN %@)) AND (dismissedAt = %@)",
+                                  predicateWithFormat:@"((presentedWhen IN %@) OR (id IN %@)) AND (dismissedAt = nil) AND (expiresAt = nil OR expiresAt > %@)",
                                   presentedWhenOptions,
                                   self.pendingTickleIds,
-                                  nil];
+                                  [NSDate date]];
 
         [fetchRequest setPredicate:predicate];
         NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"updatedAt"
@@ -593,6 +600,12 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
     dismissedAt.attributeType = NSDateAttributeType;
     dismissedAt.optional = YES;
     [messageProps addObject:dismissedAt];
+    
+    NSAttributeDescription* expiresAt = [NSAttributeDescription new];
+    expiresAt.name = @"expiresAt";
+    expiresAt.attributeType = NSDateAttributeType;
+    expiresAt.optional = YES;
+    [messageProps addObject:expiresAt];
 
     [messageEntity setProperties:messageProps];
     [model setEntities:@[messageEntity]];

--- a/Sources/InApp/KSInAppModels.h
+++ b/Sources/InApp/KSInAppModels.h
@@ -18,6 +18,7 @@
 @property (nonatomic,strong) NSDate* inboxFrom;
 @property (nonatomic,strong) NSDate* inboxTo;
 @property (nonatomic,strong) NSDate* dismissedAt;
+@property (nonatomic,strong) NSDate* expiresAt;
 
 @end
 

--- a/Sources/InApp/KSInAppModels.m
+++ b/Sources/InApp/KSInAppModels.m
@@ -35,13 +35,13 @@
 + (instancetype)fromEntity:(KSInAppMessageEntity *)entity {
     KSInAppMessage* message = [KSInAppMessage new];
 
-    message.id = entity.id;
-    message.updatedAt = entity.updatedAt;
-    message.content = entity.content;
-    message.data = entity.data;
-    message.badgeConfig = entity.badgeConfig;
-    message.inboxConfig = entity.inboxConfig;
-    message.dismissedAt = entity.dismissedAt;
+    message.id = [entity.id copy];
+    message.updatedAt = [entity.updatedAt copy];
+    message.content = [entity.content copy];
+    message.data = [entity.data copy];
+    message.badgeConfig = [entity.badgeConfig copy];
+    message.inboxConfig = [entity.inboxConfig copy];
+    message.dismissedAt = [entity.dismissedAt copy];
 
     return message;
 }

--- a/Sources/InApp/KSInAppModels.m
+++ b/Sources/InApp/KSInAppModels.m
@@ -17,6 +17,7 @@
 @dynamic inboxFrom;
 @dynamic inboxTo;
 @dynamic dismissedAt;
+@dynamic expiresAt;
 
 @end
 

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"2.3.0";
+static const NSString* KSSdkVersion = @"2.4.0";
 
 @implementation Kumulos (Stats)
 


### PR DESCRIPTION
### Description of Changes

1) Support message expiry. Add an expiresAt column. After a message is saved delete (also) expired messages. Don't read expired messages.
2) copy field values when mapping MessageEntity into Message

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
