### PR TITLE
Move NotificationServiceExtension into a pod

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -129,6 +129,10 @@
 		12D7C6862019DC5700A390CD /* KSCrash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12D7C6872019DC5700A390CD /* KSCrash.framework */; };
 		12E861DA2302C4EF009EF70B /* KSInAppPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 12E861D92302C4EF009EF70B /* KSInAppPresenter.m */; };
 		12E861DB2302C4EF009EF70B /* KSInAppPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 12E861D92302C4EF009EF70B /* KSInAppPresenter.m */; };
+		B6A4592E23992FF700FDECFC /* KumulosNotificationService.m in Sources */ = {isa = PBXBuildFile; fileRef = B6A4592C23992FF700FDECFC /* KumulosNotificationService.m */; };
+		B6A4592F2399307F00FDECFC /* KumulosSDKExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A4592723992F1E00FDECFC /* KumulosSDKExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6A45930239930E700FDECFC /* KumulosNotificationService.h in Sources */ = {isa = PBXBuildFile; fileRef = B6A4592B23992FF700FDECFC /* KumulosNotificationService.h */; };
+		B6A459322399477000FDECFC /* KumulosNotificationService.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A4592B23992FF700FDECFC /* KumulosNotificationService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -218,6 +222,11 @@
 		12D7C6872019DC5700A390CD /* KSCrash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KSCrash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		12E861D92302C4EF009EF70B /* KSInAppPresenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSInAppPresenter.m; sourceTree = "<group>"; };
 		12E861DC2302C4FD009EF70B /* KSInAppPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSInAppPresenter.h; sourceTree = "<group>"; };
+		B6A4591E23992E6E00FDECFC /* KumulosSDKExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KumulosSDKExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6A4592723992F1E00FDECFC /* KumulosSDKExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KumulosSDKExtension.h; sourceTree = "<group>"; };
+		B6A4592823992F1E00FDECFC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B6A4592B23992FF700FDECFC /* KumulosNotificationService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KumulosNotificationService.h; sourceTree = "<group>"; };
+		B6A4592C23992FF700FDECFC /* KumulosNotificationService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KumulosNotificationService.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,6 +259,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				12BBE9A420E3CD9E00DC9916 /* libKSCrashLib.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6A4591B23992E6E00FDECFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,6 +313,7 @@
 				12735B4A1E4CDD3100ED4488 /* KumulosSDK.framework */,
 				12735B811E4CDDB500ED4488 /* KumulosSDK.framework */,
 				12BBE98120E3CC4200DC9916 /* libKumulosSDKiOS.a */,
+				B6A4591E23992E6E00FDECFC /* KumulosSDKExtension.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -304,6 +321,7 @@
 		12735B8D1E4CDEAF00ED4488 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B6A4592623992F1E00FDECFC /* KumulosSDKExtension */,
 				120CD56B22DCA7F100067A45 /* InApp */,
 				12562CB620E235E5005CFCED /* Http */,
 				12735B991E4CE35900ED4488 /* KSAPIOperation.h */,
@@ -366,6 +384,17 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		B6A4592623992F1E00FDECFC /* KumulosSDKExtension */ = {
+			isa = PBXGroup;
+			children = (
+				B6A4592B23992FF700FDECFC /* KumulosNotificationService.h */,
+				B6A4592C23992FF700FDECFC /* KumulosNotificationService.m */,
+				B6A4592723992F1E00FDECFC /* KumulosSDKExtension.h */,
+				B6A4592823992F1E00FDECFC /* Info.plist */,
+			);
+			path = KumulosSDKExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -415,6 +444,15 @@
 				125CA7741F8BD5160008CAA4 /* Kumulos+Crash.h in Headers */,
 				12735B961E4CE00100ED4488 /* KumulosSDK.h in Headers */,
 				12562CB520E161AB005CFCED /* KSHttpClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6A4591923992E6E00FDECFC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6A4592F2399307F00FDECFC /* KumulosSDKExtension.h in Headers */,
+				B6A459322399477000FDECFC /* KumulosNotificationService.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -474,6 +512,24 @@
 			productReference = 12BBE98120E3CC4200DC9916 /* libKumulosSDKiOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		B6A4591D23992E6E00FDECFC /* KumulosSDKExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B6A4592323992E6E00FDECFC /* Build configuration list for PBXNativeTarget "KumulosSDKExtension" */;
+			buildPhases = (
+				B6A4591923992E6E00FDECFC /* Headers */,
+				B6A4591A23992E6E00FDECFC /* Sources */,
+				B6A4591B23992E6E00FDECFC /* Frameworks */,
+				B6A4591C23992E6E00FDECFC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KumulosSDKExtension;
+			productName = KumulosSDKExtension;
+			productReference = B6A4591E23992E6E00FDECFC /* KumulosSDKExtension.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -500,6 +556,11 @@
 						DevelopmentTeam = AY85FBK9Q6;
 						ProvisioningStyle = Automatic;
 					};
+					B6A4591D23992E6E00FDECFC = {
+						CreatedOnToolsVersion = 11.2.1;
+						DevelopmentTeam = AY85FBK9Q6;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 12735B421E4CDCA700ED4488 /* Build configuration list for PBXProject "KumulosSDK" */;
@@ -519,6 +580,7 @@
 				12735B801E4CDDB500ED4488 /* KumulosSDK macOS */,
 				12BBE98020E3CC4200DC9916 /* KumulosSDKiOS */,
 				12BBE9A520E3D2B800DC9916 /* KumulosSDKiOSCombined */,
+				B6A4591D23992E6E00FDECFC /* KumulosSDKExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -532,6 +594,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		12735B7F1E4CDDB500ED4488 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6A4591C23992E6E00FDECFC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -627,6 +696,15 @@
 				12BBE99920E3CC9600DC9916 /* KumulosEvents.m in Sources */,
 				12BD21BD2306D72C00BE0D18 /* KSUserNotificationCenterDelegate.m in Sources */,
 				12E861DB2302C4EF009EF70B /* KSInAppPresenter.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6A4591A23992E6E00FDECFC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6A45930239930E700FDECFC /* KumulosNotificationService.h in Sources */,
+				B6A4592E23992FF700FDECFC /* KumulosNotificationService.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1028,6 +1106,102 @@
 			};
 			name = Release;
 		};
+		B6A4592423992E6E00FDECFC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = AY85FBK9Q6;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = Sources/KumulosSDKExtension/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B6A4592523992E6E00FDECFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = AY85FBK9Q6;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = Sources/KumulosSDKExtension/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1072,6 +1246,15 @@
 			buildConfigurations = (
 				12BBE9A720E3D2B800DC9916 /* Debug */,
 				12BBE9A820E3D2B800DC9916 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B6A4592323992E6E00FDECFC /* Build configuration list for PBXNativeTarget "KumulosSDKExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B6A4592423992E6E00FDECFC /* Debug */,
+				B6A4592523992E6E00FDECFC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1144,6 +1144,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 3.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1189,6 +1190,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 3.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK iOS.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK iOS.xcscheme
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "12735B491E4CDD3100ED4488"
+            BuildableName = "KumulosSDK.framework"
+            BlueprintName = "KumulosSDK iOS"
+            ReferencedContainer = "container:KumulosSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "12735B491E4CDD3100ED4488"
-            BuildableName = "KumulosSDK.framework"
-            BlueprintName = "KumulosSDK iOS"
-            ReferencedContainer = "container:KumulosSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:KumulosSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B6A4591D23992E6E00FDECFC"
+               BuildableName = "KumulosSDKExtension.framework"
+               BlueprintName = "KumulosSDKExtension"
+               ReferencedContainer = "container:KumulosSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B6A4591D23992E6E00FDECFC"
+            BuildableName = "KumulosSDKExtension.framework"
+            BlueprintName = "KumulosSDKExtension"
+            ReferencedContainer = "container:KumulosSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.12"
 
   s.source_files = "Sources/**/*.{h,m}"
-  s.exclude_files = "Carthage"
+  s.exclude_files = "Carthage", "Sources/KumulosSDKExtension"
   s.module_name = "KumulosSDK"
   s.header_dir = "KumulosSDK"
   s.preserve_path = 'upload_dsyms.sh'

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "2.4.0"
+  s.version = "3.0.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -9,7 +9,6 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/Kumulos/KumulosSdkObjectiveC.git", :tag => "#{s.version}" }
 
   s.ios.deployment_target = "10.0"
-  s.osx.deployment_target = "10.12"
 
   s.source_files = "Sources/KumulosSDKExtension/**/*.{h,m}"
   s.exclude_files = "Carthage"
@@ -17,9 +16,7 @@ Pod::Spec.new do |s|
   s.header_dir = "KumulosSDK"
 
   s.ios.public_header_files = [
-    'Sources/KumulosSDKExtension/KumulosNotificationService.h',
-  ]
-  s.osx.public_header_files = [
+    'Sources/KumulosSDKExtension/KumulosSDKExtension.h',
     'Sources/KumulosSDKExtension/KumulosNotificationService.h',
   ]
 

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,0 +1,26 @@
+
+Pod::Spec.new do |s|
+  s.name = "KumulosSdkObjectiveCExtension"
+  s.version = "3.0.0"
+  s.license = "MIT"
+  s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
+  s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"
+  s.authors = { "Kumulos Ltd" => "support@kumulos.com" }
+  s.source = { :git => "https://github.com/Kumulos/KumulosSdkObjectiveC.git", :tag => "#{s.version}" }
+
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
+
+  s.source_files = "Sources/KumulosSDKExtension/**/*.{h,m}"
+  s.exclude_files = "Carthage"
+  s.module_name = "KumulosSDKExtension"
+  s.header_dir = "KumulosSDK"
+
+  s.ios.public_header_files = [
+    'Sources/KumulosSDKExtension/KumulosNotificationService.h',
+  ]
+  s.osx.public_header_files = [
+    'Sources/KumulosSDKExtension/KumulosNotificationService.h',
+  ]
+
+end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 2.4'
+pod 'KumulosSdkObjectiveC', '~> 3.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 2.4
+github "Kumulos/KumulosSdkObjectiveC" ~> 3.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Http/KSUrlEncoding.m
+++ b/Sources/Http/KSUrlEncoding.m
@@ -4,7 +4,7 @@
 //
 
 #import "KSUrlEncoding.h"
-#import "NSString+URLEncoding.m"
+#import "NSString+URLEncoding.h"
 
 // Based on recursive encoding from AFNetworking serializer
 NSArray* _Nonnull KSUrlEncodedStringFromObjectWithParent(NSString* _Nullable key, id obj) {

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>3.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Kumulos+Push.h
+++ b/Sources/Kumulos+Push.h
@@ -47,12 +47,4 @@
  * @param notification The remote notification model that was receieved by the device
  */
 - (void) pushTrackOpenFromNotification:(KSPushNotification* _Nullable)notification;
-
-/**
-* Implementation of Notification Service Extension. Handles display of pictures in notifications
-* @param request  from Notification Service Extension
-* @param contentHandler from Notification Service Extension
-*/
-+ (void) didReceiveNotificationRequest:(UNNotificationRequest * _Nonnull)request withContentHandler:(void (^_Nonnull)(UNNotificationContent * _Nonnull))contentHandler API_AVAILABLE(ios(10.0));
-
 @end

--- a/Sources/Kumulos+Push.m
+++ b/Sources/Kumulos+Push.m
@@ -5,7 +5,6 @@
 //  Copyright © 2016 kumulos. All rights reserved.
 //
 
-@import UserNotifications;
 #import <objc/runtime.h>
 #import "Kumulos+Push.h"
 #import "Kumulos+Protected.h"
@@ -21,8 +20,6 @@ static NSUInteger const KS_MESSAGE_TYPE_PUSH = 1;
 static IMP ks_existingPushRegisterDelegate = NULL;
 static IMP ks_existingPushRegisterFailDelegate = NULL;
 static IMP ks_existingPushReceiveDelegate = NULL;
-
-NSString* const _Nonnull KSMediaResizerBaseUrl = @"https://i.app.delivery";
 
 typedef void (^KSCompletionHandler)(UIBackgroundFetchResult);
 void kumulos_applicationDidRegisterForRemoteNotifications(id self, SEL _cmd, UIApplication* application, NSData* deviceToken);
@@ -190,88 +187,6 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
     }
     
     return [token copy];
-}
-
-#pragma mark - Notification service extension
-
-+ (void) didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
-    
-    UNMutableNotificationContent *bestAttemptContent = [request.content mutableCopy];
-
-    NSDictionary *userInfo = request.content.userInfo;
-    NSDictionary *attachments = userInfo == nil ? nil : userInfo[@"attachments"];
-    NSString *pictureUrl = attachments == nil ? nil : attachments[@"pictureUrl"];
-    
-    if (pictureUrl == nil) {
-        contentHandler(bestAttemptContent);
-        return;
-    }
-
-    NSString *extension = [self getPictureExtension: pictureUrl];
-    NSURL *url = [self getCompletePictureUrl: pictureUrl];
-    [self loadAttachment:url withExtension:extension
-                   completionHandler:^(UNNotificationAttachment *attachment) {
-                       if (attachment) {
-                           bestAttemptContent.attachments = [NSArray arrayWithObject:attachment];
-                       }
-                       contentHandler(bestAttemptContent);
-                   }];
-}
-
-+ (NSString * _Nullable) getPictureExtension:(NSString *) pictureUrl {
-    NSString *pictureExtension = [pictureUrl pathExtension];
-    if ([pictureExtension isEqualToString:@""]){
-       return nil;
-    }
- 
-    return [ @"." stringByAppendingString:pictureExtension];
-}
-
-+ (NSURL *) getCompletePictureUrl:(NSString *)pictureUrl {
-    if ([[pictureUrl substringWithRange:NSMakeRange(0, 8)] isEqualToString:@"https://"]
-        || [[pictureUrl substringWithRange:NSMakeRange(0, 7)] isEqualToString:@"http://"]){
-        return [NSURL URLWithString:pictureUrl];
-    }
-
-    CGFloat width = UIScreen.mainScreen.bounds.size.width;
-    NSInteger num = (NSInteger) (floor(width));
-
-    NSString *completeString = [NSString stringWithFormat:@"%@%@%ld%@%@", KSMediaResizerBaseUrl, @"/", (long) num, @"x/", pictureUrl];
-    return [NSURL URLWithString:completeString];
-}
-
-+ (void)loadAttachment:(NSURL *)url withExtension:(NSString * _Nullable)pictureExtension completionHandler:(void(^)(UNNotificationAttachment *))completionHandler API_AVAILABLE(ios(10.0)){
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-
-    [[session downloadTaskWithURL:url
-                completionHandler:^(NSURL *temporaryFileLocation, NSURLResponse *response, NSError *error) {
-                    if (error != nil) {
-                        NSLog(@"NotificationServiceExtension: %@", error.localizedDescription);
-                        completionHandler(nil);
-                        return;
-                    }
-        
-                    NSString * finalExt = pictureExtension;
-                    if (finalExt == nil){
-                        finalExt = [self getPictureExtension: [response suggestedFilename]];
-                        if (finalExt == nil){
-                            completionHandler(nil);
-                            return;
-                        }
-                    }
-
-                    NSFileManager *fileManager = [NSFileManager defaultManager];
-                    NSURL *localURL = [NSURL fileURLWithPath:[temporaryFileLocation.path stringByAppendingString:finalExt]];
-                    [fileManager moveItemAtURL:temporaryFileLocation toURL:localURL error:&error];
-
-                    NSError *attachmentError = nil;
-                    UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"" URL:localURL options:nil error:&attachmentError];
-                    if (attachmentError) {
-                        NSLog(@"NotificationServiceExtension: attachment error: %@", attachmentError.localizedDescription);
-                    }
-
-                    completionHandler(attachment);
-                }] resume];
 }
 
 @end

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"2.4.0";
+static const NSString* KSSdkVersion = @"3.0.0";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/KumulosSDKExtension/Info.plist
+++ b/Sources/KumulosSDKExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/KumulosSDKExtension/Info.plist
+++ b/Sources/KumulosSDKExtension/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,12 +13,10 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.h
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.h
@@ -1,0 +1,23 @@
+//
+//  KumulosNotificationService.h
+//  KumulosSDK
+//
+//  Created by Vladislav Voicehovics on 05/12/2019.
+//
+
+#ifndef KumulosNotificationService_h
+#define KumulosNotificationService_h
+#endif /* KumulosNotificationService_h */
+
+@import UserNotifications;
+
+@interface KumulosNotificationService : NSObject
+
+/**
+* Implementation of Notification Service Extension. Handles display of pictures in notifications
+* @param request  from Notification Service Extension
+* @param contentHandler from Notification Service Extension
+*/
++ (void) didReceiveNotificationRequest:(UNNotificationRequest * _Nonnull)request withContentHandler:(void (^_Nonnull)(UNNotificationContent * _Nonnull))contentHandler API_AVAILABLE(ios(10.0));
+
+@end

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.h
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.h
@@ -5,11 +5,10 @@
 //  Created by Vladislav Voicehovics on 05/12/2019.
 //
 
-#ifndef KumulosNotificationService_h
-#define KumulosNotificationService_h
-#endif /* KumulosNotificationService_h */
+#import <Foundation/Foundation.h>
 
 @import UserNotifications;
+@import UIKit;
 
 @interface KumulosNotificationService : NSObject
 

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.m
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.m
@@ -3,13 +3,9 @@
 //  KumulosSDK iOS
 //
 //  Created by Vladislav Voicehovics on 05/12/2019.
-//
-@import UserNotifications;
 
-#import <Foundation/Foundation.h>
 #import "KumulosNotificationService.h"
 
-#import <UIKit/UIKit.h>
 
 @implementation KumulosNotificationService
 

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.m
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.m
@@ -1,0 +1,98 @@
+//
+//  KumulosNotificationService.m
+//  KumulosSDK iOS
+//
+//  Created by Vladislav Voicehovics on 05/12/2019.
+//
+@import UserNotifications;
+
+#import <Foundation/Foundation.h>
+#import "KumulosNotificationService.h"
+
+#import <UIKit/UIKit.h>
+
+@implementation KumulosNotificationService
+
+NSString* const _Nonnull KSMediaResizerBaseUrl = @"https://i.app.delivery";
+
++ (void) didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
+    
+    UNMutableNotificationContent *bestAttemptContent = [request.content mutableCopy];
+
+    NSDictionary *userInfo = request.content.userInfo;
+    NSDictionary *attachments = userInfo == nil ? nil : userInfo[@"attachments"];
+    NSString *pictureUrl = attachments == nil ? nil : attachments[@"pictureUrl"];
+    
+    if (pictureUrl == nil) {
+        contentHandler(bestAttemptContent);
+        return;
+    }
+
+    NSString *extension = [self getPictureExtension: pictureUrl];
+    NSURL *url = [self getCompletePictureUrl: pictureUrl];
+    [self loadAttachment:url withExtension:extension
+                   completionHandler:^(UNNotificationAttachment *attachment) {
+                       if (attachment) {
+                           bestAttemptContent.attachments = [NSArray arrayWithObject:attachment];
+                       }
+                       contentHandler(bestAttemptContent);
+                   }];
+}
+
++ (NSString * _Nullable) getPictureExtension:(NSString *) pictureUrl {
+    NSString *pictureExtension = [pictureUrl pathExtension];
+    if ([pictureExtension isEqualToString:@""]){
+       return nil;
+    }
+ 
+    return [ @"." stringByAppendingString:pictureExtension];
+}
+
++ (NSURL *) getCompletePictureUrl:(NSString *)pictureUrl {
+    if ([[pictureUrl substringWithRange:NSMakeRange(0, 8)] isEqualToString:@"https://"]
+        || [[pictureUrl substringWithRange:NSMakeRange(0, 7)] isEqualToString:@"http://"]){
+        return [NSURL URLWithString:pictureUrl];
+    }
+
+    CGFloat width = UIScreen.mainScreen.bounds.size.width;
+    NSInteger num = (NSInteger) (floor(width));
+
+    NSString *completeString = [NSString stringWithFormat:@"%@%@%ld%@%@", KSMediaResizerBaseUrl, @"/", (long) num, @"x/", pictureUrl];
+    return [NSURL URLWithString:completeString];
+}
+
++ (void)loadAttachment:(NSURL *)url withExtension:(NSString * _Nullable)pictureExtension completionHandler:(void(^)(UNNotificationAttachment *))completionHandler API_AVAILABLE(ios(10.0)){
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+
+    [[session downloadTaskWithURL:url
+                completionHandler:^(NSURL *temporaryFileLocation, NSURLResponse *response, NSError *error) {
+                    if (error != nil) {
+                        NSLog(@"NotificationServiceExtension: %@", error.localizedDescription);
+                        completionHandler(nil);
+                        return;
+                    }
+        
+                    NSString * finalExt = pictureExtension;
+                    if (finalExt == nil){
+                        finalExt = [self getPictureExtension: [response suggestedFilename]];
+                        if (finalExt == nil){
+                            completionHandler(nil);
+                            return;
+                        }
+                    }
+
+                    NSFileManager *fileManager = [NSFileManager defaultManager];
+                    NSURL *localURL = [NSURL fileURLWithPath:[temporaryFileLocation.path stringByAppendingString:finalExt]];
+                    [fileManager moveItemAtURL:temporaryFileLocation toURL:localURL error:&error];
+
+                    NSError *attachmentError = nil;
+                    UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"" URL:localURL options:nil error:&attachmentError];
+                    if (attachmentError) {
+                        NSLog(@"NotificationServiceExtension: attachment error: %@", attachmentError.localizedDescription);
+                    }
+
+                    completionHandler(attachment);
+                }] resume];
+}
+
+@end

--- a/Sources/KumulosSDKExtension/KumulosSDKExtension.h
+++ b/Sources/KumulosSDKExtension/KumulosSDKExtension.h
@@ -1,0 +1,18 @@
+//
+//  KumulosSDKExtension.h
+//  KumulosSDKExtension
+//
+//  Created by Vladislav Voicehovics on 05/12/2019.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for KumulosSDKExtension.
+FOUNDATION_EXPORT double KumulosSDKExtensionVersionNumber;
+
+//! Project version string for KumulosSDKExtension.
+FOUNDATION_EXPORT const unsigned char KumulosSDKExtensionVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <KumulosSDKExtension/PublicHeader.h>
+
+

--- a/Sources/KumulosSDKExtension/KumulosSDKExtension.h
+++ b/Sources/KumulosSDKExtension/KumulosSDKExtension.h
@@ -15,4 +15,4 @@ FOUNDATION_EXPORT const unsigned char KumulosSDKExtensionVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <KumulosSDKExtension/PublicHeader.h>
 
-
+#import "KumulosNotificationService.h"


### PR DESCRIPTION
### Description of Changes

When adding the SDK as a dependency for a notification service extension target in a CocoaPods app, the link step fails due to KSCrash consuming unavailable APIs.

This PR splits out the notification service helper code into a separate target and Podspec which allows linking as a separate framework, avoiding the notification service extension issues.

This means a consumer will integrate as follows:

```ruby
target 'YourApp' do
  pod 'KumulosSdkObjectiveC'
end

target 'YourAppExtension' do
  pod 'KumulosSdkObjectiveCExtension'
end
```

### Breaking Changes

-  [Kumulos didReceiveNotificationRequest:withContentHandler]; helper removed from base SDK and moved to the KumulosNotificationService class in the KumulosSDKExtension target

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
