### PR TITLE
Allow handling local notifications with your own delegate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Bump versions in:
 
 -   [ ] `Sources/Kumulos+Stats.m`
 -   [ ] `KumulosSdkObjectiveC.podspec`
+-   [ ] `KumulosSdkObjectiveCExtension.podspec`
 -   [ ] `Sources/Info-*.plist`
 -   [ ] `README.md`
 

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -830,6 +830,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -885,6 +886,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -947,6 +949,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1002,6 +1005,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1144,7 +1148,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1190,7 +1194,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "3.0.0"
+  s.version = "3.1.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "3.0.0"
+  s.version = "3.1.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 3.0'
+pod 'KumulosSdkObjectiveC', '~> 3.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 3.0
+github "Kumulos/KumulosSdkObjectiveC" ~> 3.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Info-iOS.plist
+++ b/Sources/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Info-macOS.plist
+++ b/Sources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/KSUserNotificationCenterDelegate.m
+++ b/Sources/KSUserNotificationCenterDelegate.m
@@ -6,17 +6,24 @@
 #import "KSUserNotificationCenterDelegate.h"
 #import "Kumulos+PushProtected.h"
 
+API_AVAILABLE(ios(10.0))
 @interface KSUserNotificationCenterDelegate ()
 
 @property (nonatomic) Kumulos* kumulos;
+@property (nonatomic,weak) id <UNUserNotificationCenterDelegate> existingDelegate;
 
 @end
 
+API_AVAILABLE(ios(10.0))
 @implementation KSUserNotificationCenterDelegate
 
 - (instancetype)initWithKumulos:(Kumulos *)kumulos {
     if (self = [super init]) {
         self.kumulos = kumulos;
+
+        if (UNUserNotificationCenter.currentNotificationCenter.delegate) {
+            self.existingDelegate = UNUserNotificationCenter.currentNotificationCenter.delegate;
+        }
     }
 
     return self;
@@ -24,23 +31,60 @@
 
 // Called on iOS10+ when your app is in the foreground to allow customizing the display of the notification
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-    if (self.kumulos.config.pushReceivedInForegroundHandler) {
-        KSPushNotification* push = [KSPushNotification fromUserInfo:notification.request.content.userInfo];
-        self.kumulos.config.pushReceivedInForegroundHandler(push, completionHandler);
-    } else {
-        completionHandler(UNNotificationPresentationOptionAlert);
+    NSDictionary* userInfo = notification.request.content.userInfo;
+    KSPushNotification* push = [KSPushNotification fromUserInfo:userInfo];
+
+    if (!push || !push.id) {
+        [self chainCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+        return;
     }
+
+    if (!self.kumulos.config.pushReceivedInForegroundHandler) {
+        completionHandler(UNNotificationPresentationOptionAlert);
+        return;
+    }
+
+    self.kumulos.config.pushReceivedInForegroundHandler(push, completionHandler);
 }
 
 // iOS10+ handler for when a user taps a notification
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+    NSDictionary* userInfo = response.notification.request.content.userInfo;
+
+    if (!userInfo || !userInfo[@"aps"]) {
+        [self chainCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+        return;
+    }
+
     if ([response.actionIdentifier isEqualToString:UNNotificationDismissActionIdentifier]) {
         completionHandler();
         return;
     }
 
-    NSDictionary* userInfo = response.notification.request.content.userInfo;
-    [self.kumulos pushHandleOpenWithUserInfo:userInfo];
+    BOOL handled = [self.kumulos pushHandleOpenWithUserInfo:userInfo];
+
+    if (!handled) {
+        [self chainCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+        return;
+    }
+
+    completionHandler();
+}
+
+- (void) chainCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    if (self.existingDelegate && [self.existingDelegate respondsToSelector:@selector(userNotificationCenter:willPresentNotification:withCompletionHandler:)]) {
+        [self.existingDelegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+        return;
+    }
+
+    completionHandler(UNNotificationPresentationOptionAlert);
+}
+
+- (void) chainCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+    if (self.existingDelegate && [self.existingDelegate respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)]) {
+        [self.existingDelegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+        return;
+    }
 
     completionHandler();
 }

--- a/Sources/Kumulos+Push.h
+++ b/Sources/Kumulos+Push.h
@@ -10,7 +10,7 @@
 
 @interface KSPushNotification : NSObject
 
-+ (instancetype _Nonnull) fromUserInfo:(NSDictionary* _Nonnull)userInfo;
++ (instancetype _Nullable) fromUserInfo:(NSDictionary* _Nullable)userInfo;
 
 @property (nonatomic,readonly) NSNumber* _Nonnull id;
 @property (nonatomic,readonly) NSDictionary* _Nonnull aps;

--- a/Sources/Kumulos+Push.m
+++ b/Sources/Kumulos+Push.m
@@ -29,6 +29,10 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
 @implementation KSPushNotification
 
 + (instancetype) fromUserInfo:(NSDictionary*)userInfo {
+    if  (!userInfo || !userInfo[@"aps"] || !userInfo[@"custom"] || !userInfo[@"custom"][@"a"] || !userInfo[@"custom"][@"a"][@"k.message"]) {
+        return nil;
+    }
+
     KSPushNotification* notification = [KSPushNotification new];
 
     NSDictionary* custom = userInfo[@"custom"];
@@ -136,12 +140,13 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
     [self.analyticsHelper trackEvent:KumulosEventMessageOpened withProperties:params];
 }
 
-- (void) pushHandleOpenWithUserInfo:(NSDictionary*)userInfo {
-    if (!userInfo) {
-        return;
+- (BOOL) pushHandleOpenWithUserInfo:(NSDictionary*)userInfo {
+    KSPushNotification* notification = [KSPushNotification fromUserInfo:userInfo];
+
+    if (!notification || !notification.id) {
+        return NO;
     }
 
-    KSPushNotification* notification = [KSPushNotification fromUserInfo:userInfo];
     [self pushTrackOpenFromNotification:notification];
 
     // Handle URL pushes
@@ -164,6 +169,8 @@ void kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler(id se
             self.config.pushOpenedHandler(notification);
         });
     }
+
+    return YES;
 }
 
 - (NSNumber*) pushGetTokenType {

--- a/Sources/Kumulos+PushProtected.h
+++ b/Sources/Kumulos+PushProtected.h
@@ -9,6 +9,6 @@
 @interface Kumulos (PushProtected)
 
 - (void) pushInit;
-- (void) pushHandleOpenWithUserInfo:(NSDictionary* _Nullable)userInfo;
+- (BOOL) pushHandleOpenWithUserInfo:(NSDictionary* _Nullable)userInfo;
 
 @end

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"3.0.0";
+static const NSString* KSSdkVersion = @"3.1.0";
 
 @implementation Kumulos (Stats)
 


### PR DESCRIPTION
### Description of Changes

Allow handling local notifications with your own implementation of `UNUserNotificationCenterDelegate`.

The delegate must be set as the current notification center delegate prior to initializing Kumulos. In addition, the delegate must be strongly retained (the SDK will not retain it).

Fixes #41.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
