### PR TITLE
Delete messages from inbox 

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -926,7 +926,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.1.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -982,7 +982,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1332,7 +1332,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1378,7 +1378,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "4.0.1"
+  s.version = "4.1.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "4.0.1"
+  s.version = "4.1.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 4.0'
+pod 'KumulosSdkObjectiveC', '~> 4.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 4.0
+github "Kumulos/KumulosSdkObjectiveC" ~> 4.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/KSInAppHelper.h
+++ b/Sources/InApp/KSInAppHelper.h
@@ -28,5 +28,6 @@ extern NSString* _Nonnull const KSInAppPresentedFromInbox;
 - (void) handleAssociatedUserChange;
 - (void) handlePushOpen:(KSPushNotification* _Nonnull)notification;
 - (BOOL) presentMessageWithId:(NSNumber* _Nonnull)messageId;
-
+- (BOOL) deleteMessageFromInbox:(NSNumber* _Nonnull)messageId;
+    
 @end

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"4.0.1";
+static const NSString* KSSdkVersion = @"4.1.0";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/KumulosEvents.h
+++ b/Sources/KumulosEvents.h
@@ -18,3 +18,4 @@ extern NSString* const KumulosEventInAppConsentChanged;
 extern NSString* const KumulosEventMessageOpened;
 extern NSString* const KumulosEventMessageDelivered;
 extern NSString* const KumulosEventMessageDismissed;
+extern NSString* const KumulosEventMessageDeletedFromInbox;

--- a/Sources/KumulosEvents.m
+++ b/Sources/KumulosEvents.m
@@ -18,3 +18,4 @@ NSString* const KumulosEventInAppConsentChanged = @"k.inApp.statusUpdated";
 NSString* const KumulosEventMessageOpened = @"k.message.opened";
 NSString* const KumulosEventMessageDelivered = @"k.message.delivered";
 NSString* const KumulosEventMessageDismissed = @"k.message.dismissed";
+NSString* const KumulosEventMessageDeletedFromInbox = @"k.message.inbox.deleted";

--- a/Sources/KumulosInApp.h
+++ b/Sources/KumulosInApp.h
@@ -37,4 +37,5 @@ typedef NS_ENUM(NSInteger, KSInAppMessagePresentationResult) {
 
 + (KSInAppMessagePresentationResult) presentInboxMessage:(KSInAppInboxItem* _Nonnull)item;
 
++ (BOOL) deleteMessageFromInbox:(KSInAppInboxItem* _Nonnull)item;
 @end

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -97,5 +97,9 @@
     return result ? KSInAppMessagePresentationPresented : KSInAppMessagePresentationFailed;
 }
 
++ (BOOL)deleteMessageFromInbox:(KSInAppInboxItem *)item {
+    return [Kumulos.shared.inAppHelper deleteMessageFromInbox:item.id];
+}
+
 @end
 


### PR DESCRIPTION
### Description of Changes

New public function `deleteMessageFromInbox:item`. It sends `k.message.inbox.deleted` event and sets inbox columns to nil. This transforms the message into a message without inbox. Eviction/presentation rules of a message without inbox apply.

Additionally, when saving messages:

- update dismissedAt only if it is currently nil
- set inbox columns to nil if payload contains `inboxDeletedAt`

Ported from Swift https://github.com/Kumulos/KumulosSdkSwift/pull/50

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] All relevant build targets
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
