### PR TITLE
On inbox updated API change

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1212,7 +1212,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -1268,7 +1268,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1331,7 +1331,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1387,7 +1387,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1656,7 +1656,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1702,7 +1702,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "4.5.1"
+  s.version = "5.0.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "4.5.1"
+  s.version = "5.0.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 4.5'
+pod 'KumulosSdkObjectiveC', '~> 5.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 4.5
+github "Kumulos/KumulosSdkObjectiveC" ~> 5.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/KSInAppHelper.h
+++ b/Sources/InApp/KSInAppHelper.h
@@ -32,7 +32,6 @@ extern NSString* _Nonnull const KSInAppPresentedFromInbox;
 - (BOOL) deleteMessageFromInbox:(NSNumber* _Nonnull)messageId;
 - (BOOL) markInboxItemRead:(NSNumber* _Nonnull)withId shouldWait:(BOOL)shouldWait;
 - (BOOL) markAllInboxItemsAsRead;
-- (void) setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock;
 - (void) maybeRunInboxUpdatedHandler:(BOOL)inboxNeedsUpdate;
 - (void) readInboxSummary:(InboxSummaryBlock)inboxSummaryBlock;
 @end

--- a/Sources/InApp/KSInAppHelper.m
+++ b/Sources/InApp/KSInAppHelper.m
@@ -37,7 +37,6 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
 @implementation KSInAppHelper
 
 int const STORED_IN_APP_LIMIT = 50;
-InboxUpdatedHandlerBlock _inboxUpdatedHandlerBlock = nil;
 
 #pragma mark - Initialization
 
@@ -756,17 +755,13 @@ InboxUpdatedHandlerBlock _inboxUpdatedHandlerBlock = nil;
     return result;
 }
 
-- (void)setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock {
-    _inboxUpdatedHandlerBlock = inboxUpdatedHandlerBlock;
-}
-
 - (void)maybeRunInboxUpdatedHandler:(BOOL)inboxNeedsUpdate {
     if (!inboxNeedsUpdate){
         return;
     }
 
-    if (_inboxUpdatedHandlerBlock != nil){
-        dispatch_async(dispatch_get_main_queue(), _inboxUpdatedHandlerBlock);
+    if (self.kumulos.config.inboxUpdatedHandler != nil) {
+        dispatch_async(dispatch_get_main_queue(), self.kumulos.config.inboxUpdatedHandler);
     }
 }
 

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"4.5.1";
+static const NSString* KSSdkVersion = @"5.0.0";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, KSDeepLinkResolution) {
     KSDeepLinkResolutionLinkMatched,
 };
 typedef void (^ _Nullable KSDeepLinkHandlerBlock)(KSDeepLinkResolution resolution, NSURL* _Nonnull url, KSDeepLink* _Nullable link);
-
+typedef void (^ _Nullable InboxUpdatedHandlerBlock)(void);
 
 API_AVAILABLE(ios(10.0), macos(10.14))
 typedef void (^ _Nonnull KSPushReceivedInForegroundCompletionHandler)(UNNotificationPresentationOptions);
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 @property (nonatomic,readonly) KSInAppConsentStrategy inAppConsentStrategy;
 @property (nonatomic,readonly) KSInAppDeepLinkHandlerBlock inAppDeepLinkHandler;
 @property (nonatomic,readonly) KSPushOpenedHandlerBlock pushOpenedHandler;
+@property (nonatomic,readonly) InboxUpdatedHandlerBlock inboxUpdatedHandler;
 @property (nonatomic,readonly) KSPushReceivedInForegroundHandlerBlock pushReceivedInForegroundHandler API_AVAILABLE(ios(10.0), macos(10.14));
 
 @property (nonatomic,readonly) KSDeepLinkHandlerBlock _Nullable deepLinkHandler;
@@ -85,6 +86,7 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 - (instancetype _Nonnull) enableInAppMessaging:(KSInAppConsentStrategy)consentStrategy;
 - (instancetype _Nonnull) setInAppDeepLinkHandler:(KSInAppDeepLinkHandlerBlock)deepLinkHandler;
 - (instancetype _Nonnull) setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler;
+- (instancetype _Nonnull) setInboxUpdatedHandler:(InboxUpdatedHandlerBlock)inboxUpdatedHandler;
 - (instancetype _Nonnull) setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler API_AVAILABLE(ios(10.0),macos(10.14));
 - (instancetype _Nonnull) setForegroundPushPresentationOptions:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14));
 - (instancetype _Nonnull) enableDeepLinking:(NSString* _Nonnull)cname deepLinkHandler:(KSDeepLinkHandlerBlock)deepLinkHandler;

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -49,6 +49,7 @@ static NSString * const KSCrmCoreBaseUrl = @"https://crm.kumulos.com";
         self->_inAppConsentStrategy = KSInAppConsentStrategyNotEnabled;
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
+        self->_inboxUpdatedHandler = nil;
         self->_pushReceivedInForegroundHandler = nil;
         self->_deepLinkHandler = nil;
         self->_deepLinkCname = nil;
@@ -93,6 +94,11 @@ static NSString * const KSCrmCoreBaseUrl = @"https://crm.kumulos.com";
 
 - (instancetype)setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler {
     self->_pushOpenedHandler = notificationHandler;
+    return self;
+}
+
+- (instancetype)setInboxUpdatedHandler:(InboxUpdatedHandlerBlock)inboxUpdatedHandler {
+    self->_inboxUpdatedHandler = inboxUpdatedHandler;
     return self;
 }
 

--- a/Sources/KumulosInApp.h
+++ b/Sources/KumulosInApp.h
@@ -34,7 +34,6 @@ typedef NS_ENUM(NSInteger, KSInAppMessagePresentationResult) {
 + (instancetype _Nonnull) init:(int)totalCount unreadCount:(int)unreadCount;
 @end
 
-typedef void (^ _Nullable InboxUpdatedHandlerBlock)(void);
 typedef void (^ _Nullable InboxSummaryBlock)(InAppInboxSummary* _Nullable inboxSummary);
 
 
@@ -58,8 +57,6 @@ typedef void (^ _Nullable InboxSummaryBlock)(InAppInboxSummary* _Nullable inboxS
 + (BOOL) markAsRead:(KSInAppInboxItem* _Nonnull)item;
 
 + (BOOL) markAllInboxItemsAsRead;
-
-+ (void) setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock;
 
 + (void) getInboxSummaryAsync:(InboxSummaryBlock)inboxSummaryBlock;
 

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -163,10 +163,6 @@ int const DEFAULT_IMAGE_WIDTH = 300;
     return [Kumulos.shared.inAppHelper markAllInboxItemsAsRead];
 }
 
-+ (void)setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock {
-    [Kumulos.shared.inAppHelper setOnInboxUpdated:inboxUpdatedHandlerBlock];
-}
-
 + (void)getInboxSummaryAsync:(InboxSummaryBlock)inboxSummaryBlock {
     [Kumulos.shared.inAppHelper readInboxSummary:inboxSummaryBlock];
 }


### PR DESCRIPTION
### Description of Changes

Change API for setting onInboxUpdated handler from 
```
[KumulosInApp setInboxUpdatedHandler:^(){
   //do stuff
 }];
```
to

```
[config setInboxUpdatedHandler:^(){
   //do stuff      
 }];
```

This is a) in line with how other handlers are set b) avoids potential sequencing issues (`initialize` needed to be called before `setInboxUpdatedHandler`)
### Breaking Changes

API for setting inbox updated handler has changed. 

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes
-   [x] Check all targets (iOS, extension, macOS, statics) build
-   [x] Install branch via Cocoapods into empty project & verify can import SDK (only needed if adding/removing files)

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] All relevant build targets
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
