### PR TITLE
Undo API change

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1212,7 +1212,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -1268,7 +1268,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1331,7 +1331,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1387,7 +1387,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1656,7 +1656,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1702,7 +1702,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.5.1;
+				MARKETING_VERSION = 4.5.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1212,7 +1212,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -1268,7 +1268,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1331,7 +1331,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1387,7 +1387,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1656,7 +1656,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1702,7 +1702,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 4.5.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "4.5.1"
+  s.version = "4.5.2"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "5.0.0"
+  s.version = "4.5.1"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "5.0.0"
+  s.version = "4.5.1"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "4.5.1"
+  s.version = "4.5.2"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 5.0'
+pod 'KumulosSdkObjectiveC', '~> 4.5'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 5.0
+github "Kumulos/KumulosSdkObjectiveC" ~> 4.5
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/KSInAppHelper.h
+++ b/Sources/InApp/KSInAppHelper.h
@@ -32,6 +32,7 @@ extern NSString* _Nonnull const KSInAppPresentedFromInbox;
 - (BOOL) deleteMessageFromInbox:(NSNumber* _Nonnull)messageId;
 - (BOOL) markInboxItemRead:(NSNumber* _Nonnull)withId shouldWait:(BOOL)shouldWait;
 - (BOOL) markAllInboxItemsAsRead;
+- (void) setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock;
 - (void) maybeRunInboxUpdatedHandler:(BOOL)inboxNeedsUpdate;
 - (void) readInboxSummary:(InboxSummaryBlock)inboxSummaryBlock;
 @end

--- a/Sources/InApp/KSInAppHelper.m
+++ b/Sources/InApp/KSInAppHelper.m
@@ -37,6 +37,7 @@ void kumulos_applicationPerformFetchWithCompletionHandler(id self, SEL _cmd, UIA
 @implementation KSInAppHelper
 
 int const STORED_IN_APP_LIMIT = 50;
+InboxUpdatedHandlerBlock _inboxUpdatedHandlerBlock = nil;
 
 #pragma mark - Initialization
 
@@ -755,13 +756,17 @@ int const STORED_IN_APP_LIMIT = 50;
     return result;
 }
 
+- (void)setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock {
+    _inboxUpdatedHandlerBlock = inboxUpdatedHandlerBlock;
+}
+
 - (void)maybeRunInboxUpdatedHandler:(BOOL)inboxNeedsUpdate {
     if (!inboxNeedsUpdate){
         return;
     }
 
-    if (self.kumulos.config.inboxUpdatedHandler != nil) {
-        dispatch_async(dispatch_get_main_queue(), self.kumulos.config.inboxUpdatedHandler);
+    if (_inboxUpdatedHandlerBlock != nil){
+        dispatch_async(dispatch_get_main_queue(), _inboxUpdatedHandlerBlock);
     }
 }
 

--- a/Sources/InApp/KSInAppModels.h
+++ b/Sources/InApp/KSInAppModels.h
@@ -17,7 +17,6 @@
 @property (nonatomic,strong) NSDictionary* inboxConfig;
 @property (nonatomic,strong) NSDate* inboxFrom;
 @property (nonatomic,strong) NSDate* inboxTo;
-@property (nonatomic,strong) NSString* inboxImagePath;
 @property (nonatomic,strong) NSDate* dismissedAt;
 @property (nonatomic,strong) NSDate* expiresAt;
 @property (nonatomic,strong) NSDate* readAt;

--- a/Sources/InApp/KSInAppModels.m
+++ b/Sources/InApp/KSInAppModels.m
@@ -16,7 +16,6 @@
 @dynamic inboxConfig;
 @dynamic inboxFrom;
 @dynamic inboxTo;
-@dynamic inboxImagePath;
 @dynamic dismissedAt;
 @dynamic expiresAt;
 @dynamic readAt;

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"4.5.1";
+static const NSString* KSSdkVersion = @"4.5.2";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"5.0.0";
+static const NSString* KSSdkVersion = @"4.5.1";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, KSDeepLinkResolution) {
     KSDeepLinkResolutionLinkMatched,
 };
 typedef void (^ _Nullable KSDeepLinkHandlerBlock)(KSDeepLinkResolution resolution, NSURL* _Nonnull url, KSDeepLink* _Nullable link);
-typedef void (^ _Nullable InboxUpdatedHandlerBlock)(void);
+
 
 API_AVAILABLE(ios(10.0), macos(10.14))
 typedef void (^ _Nonnull KSPushReceivedInForegroundCompletionHandler)(UNNotificationPresentationOptions);
@@ -70,7 +70,6 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 @property (nonatomic,readonly) KSInAppConsentStrategy inAppConsentStrategy;
 @property (nonatomic,readonly) KSInAppDeepLinkHandlerBlock inAppDeepLinkHandler;
 @property (nonatomic,readonly) KSPushOpenedHandlerBlock pushOpenedHandler;
-@property (nonatomic,readonly) InboxUpdatedHandlerBlock inboxUpdatedHandler;
 @property (nonatomic,readonly) KSPushReceivedInForegroundHandlerBlock pushReceivedInForegroundHandler API_AVAILABLE(ios(10.0), macos(10.14));
 
 @property (nonatomic,readonly) KSDeepLinkHandlerBlock _Nullable deepLinkHandler;
@@ -86,7 +85,6 @@ typedef NS_ENUM(NSInteger, KSInAppConsentStrategy) {
 - (instancetype _Nonnull) enableInAppMessaging:(KSInAppConsentStrategy)consentStrategy;
 - (instancetype _Nonnull) setInAppDeepLinkHandler:(KSInAppDeepLinkHandlerBlock)deepLinkHandler;
 - (instancetype _Nonnull) setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler;
-- (instancetype _Nonnull) setInboxUpdatedHandler:(InboxUpdatedHandlerBlock)inboxUpdatedHandler;
 - (instancetype _Nonnull) setPushReceivedInForegroundHandler:(KSPushReceivedInForegroundHandlerBlock)receivedHandler API_AVAILABLE(ios(10.0),macos(10.14));
 - (instancetype _Nonnull) setForegroundPushPresentationOptions:(UNNotificationPresentationOptions)notificationPresentationOptions API_AVAILABLE(ios(10.0),macos(10.14));
 - (instancetype _Nonnull) enableDeepLinking:(NSString* _Nonnull)cname deepLinkHandler:(KSDeepLinkHandlerBlock)deepLinkHandler;

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -49,7 +49,6 @@ static NSString * const KSCrmCoreBaseUrl = @"https://crm.kumulos.com";
         self->_inAppConsentStrategy = KSInAppConsentStrategyNotEnabled;
         self->_inAppDeepLinkHandler = nil;
         self->_pushOpenedHandler = nil;
-        self->_inboxUpdatedHandler = nil;
         self->_pushReceivedInForegroundHandler = nil;
         self->_deepLinkHandler = nil;
         self->_deepLinkCname = nil;
@@ -94,11 +93,6 @@ static NSString * const KSCrmCoreBaseUrl = @"https://crm.kumulos.com";
 
 - (instancetype)setPushOpenedHandler:(KSPushOpenedHandlerBlock)notificationHandler {
     self->_pushOpenedHandler = notificationHandler;
-    return self;
-}
-
-- (instancetype)setInboxUpdatedHandler:(InboxUpdatedHandlerBlock)inboxUpdatedHandler {
-    self->_inboxUpdatedHandler = inboxUpdatedHandler;
     return self;
 }
 

--- a/Sources/KumulosInApp.h
+++ b/Sources/KumulosInApp.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, KSInAppMessagePresentationResult) {
 + (instancetype _Nonnull) init:(int)totalCount unreadCount:(int)unreadCount;
 @end
 
+typedef void (^ _Nullable InboxUpdatedHandlerBlock)(void);
 typedef void (^ _Nullable InboxSummaryBlock)(InAppInboxSummary* _Nullable inboxSummary);
 
 
@@ -57,6 +58,8 @@ typedef void (^ _Nullable InboxSummaryBlock)(InAppInboxSummary* _Nullable inboxS
 + (BOOL) markAsRead:(KSInAppInboxItem* _Nonnull)item;
 
 + (BOOL) markAllInboxItemsAsRead;
+
++ (void) setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock;
 
 + (void) getInboxSummaryAsync:(InboxSummaryBlock)inboxSummaryBlock;
 

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -8,7 +8,7 @@
 
 @interface KSInAppInboxItem()
 
-@property (nonatomic,readonly) NSString* _Nonnull imagePath;
+@property (nonatomic,readonly) NSString* _Nullable imagePath;
 @property (nonatomic,readonly) NSDate* _Nullable readAt;
 
 @end

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -164,6 +164,12 @@ int const DEFAULT_IMAGE_WIDTH = 300;
 }
 
 + (void)setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock {
+    if (Kumulos.shared.inAppHelper == nil){
+        [NSException raise:@"Could not set InboxUpdatedHandler" format:@"Kumulos should be initialized before setting handler"];
+        
+        return;
+    }
+  
     [Kumulos.shared.inAppHelper setOnInboxUpdated:inboxUpdatedHandlerBlock];
 }
 

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -163,6 +163,10 @@ int const DEFAULT_IMAGE_WIDTH = 300;
     return [Kumulos.shared.inAppHelper markAllInboxItemsAsRead];
 }
 
++ (void)setOnInboxUpdated:(InboxUpdatedHandlerBlock)inboxUpdatedHandlerBlock {
+    [Kumulos.shared.inAppHelper setOnInboxUpdated:inboxUpdatedHandlerBlock];
+}
+
 + (void)getInboxSummaryAsync:(InboxSummaryBlock)inboxSummaryBlock {
     [Kumulos.shared.inAppHelper readInboxSummary:inboxSummaryBlock];
 }


### PR DESCRIPTION
This reverts commit bf50bef55fea0ae6272095ad4057151d3d86e45e.

### Description of Changes

1) decided not to go forward with changing onInboxUpdated API
2) tiny tweaks: remove `inboxImagePath` property as not used, annotate imagePath as nullable
3) throw when kumulos not initialised when setting onInboxUpdatedHandler


### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes
-   [x] Check all targets (iOS, extension, macOS, statics) build
-   [x] Install branch via Cocoapods into empty project & verify can import SDK (only needed if adding/removing files)

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] All relevant build targets
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
