### PR TITLE
IOS15 UNNotificationActionIcon support

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1222,7 +1222,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -1278,7 +1278,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1341,7 +1341,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1397,7 +1397,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1666,7 +1666,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1712,7 +1712,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.6.0;
+				MARKETING_VERSION = 4.7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "4.6.0"
+  s.version = "4.7.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "4.6.0"
+  s.version = "4.7.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 4.6
+github "Kumulos/KumulosSdkObjectiveC" ~> 4.7
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 4.6'
+pod 'KumulosSdkObjectiveC', '~> 4.7'
 ```
 
 Run `pod install` to install your dependencies.

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"4.6.0";
+static const NSString* KSSdkVersion = @"4.7.0";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.m
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.m
@@ -76,13 +76,42 @@ static KSAnalyticsHelper* _Nullable analyticsHelper;
     }
     
     for (NSDictionary* button in buttons) {
-        UNNotificationAction* action = [UNNotificationAction actionWithIdentifier:button[@"id"]
-                                                                            title:button[@"text"]
-                                                                          options:UNNotificationActionOptionForeground];
-        [actionArray addObject: action];
+        if (@available(macCatalyst 15.0, *)) {
+            UNNotificationActionIcon* icon = [self getButtonIcon:button];
+            UNNotificationAction* action = [UNNotificationAction actionWithIdentifier:button[@"id"]
+                                                                                title:button[@"text"]
+                                                                              options:UNNotificationActionOptionForeground
+                                                                                 icon: icon];
+            [actionArray addObject: action];
+        } else {
+            UNNotificationAction* action = [UNNotificationAction actionWithIdentifier:button[@"id"]
+                                                                                title:button[@"text"]
+                                                                              options:UNNotificationActionOptionForeground];
+            [actionArray addObject: action];
+        }
     }
     
     return actionArray;
+}
+
++ (UNNotificationActionIcon*) getButtonIcon:(NSDictionary*) buttonInfo{
+    NSDictionary* iconDict = buttonInfo == nil ? nil : buttonInfo[@"icon"];
+    if (iconDict == nil) {
+        return nil;
+    }
+    
+    NSString* type = iconDict[@"type"];
+    NSString* icon = iconDict[@"icon"];
+    
+    if (type == nil || icon == nil) {
+        return nil;
+    }
+    
+    if ([type  isEqual: @"system"]) {
+        return [UNNotificationActionIcon iconWithSystemImageName: type];
+    }
+    
+    return [UNNotificationActionIcon iconWithTemplateImageName: type];
 }
     
 + (void) addCategory:(UNMutableNotificationContent *)bestAttemptContent actionArray:(NSMutableArray*) actionArray messageId:(NSNumber*) messageId{

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.m
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.m
@@ -94,25 +94,27 @@ static KSAnalyticsHelper* _Nullable analyticsHelper;
     return actionArray;
 }
 
-+ (UNNotificationActionIcon*) getButtonIcon:(NSDictionary*) buttonInfo{
+
++ (UNNotificationActionIcon*) getButtonIcon:(NSDictionary*)buttonInfo API_AVAILABLE(ios(15)) {
     NSDictionary* iconDict = buttonInfo == nil ? nil : buttonInfo[@"icon"];
     if (iconDict == nil) {
         return nil;
     }
     
     NSString* type = iconDict[@"type"];
-    NSString* icon = iconDict[@"icon"];
+    NSString* iconId = iconDict[@"id"];
     
-    if (type == nil || icon == nil) {
+    if (type == nil || iconId == nil) {
         return nil;
     }
     
     if ([type  isEqual: @"system"]) {
-        return [UNNotificationActionIcon iconWithSystemImageName: type];
+        return [UNNotificationActionIcon iconWithSystemImageName: iconId];
     }
     
-    return [UNNotificationActionIcon iconWithTemplateImageName: type];
+    return [UNNotificationActionIcon iconWithTemplateImageName: iconId];
 }
+
     
 + (void) addCategory:(UNMutableNotificationContent *)bestAttemptContent actionArray:(NSMutableArray*) actionArray messageId:(NSNumber*) messageId{
   

--- a/Sources/KumulosSDKExtension/KumulosNotificationService.m
+++ b/Sources/KumulosSDKExtension/KumulosNotificationService.m
@@ -76,7 +76,7 @@ static KSAnalyticsHelper* _Nullable analyticsHelper;
     }
     
     for (NSDictionary* button in buttons) {
-        if (@available(macCatalyst 15.0, *)) {
+        if (@available(iOS 15.0, *)) {
             UNNotificationActionIcon* icon = [self getButtonIcon:button];
             UNNotificationAction* action = [UNNotificationAction actionWithIdentifier:button[@"id"]
                                                                                 title:button[@"text"]


### PR DESCRIPTION
### Description of Changes

Add support for UNNotificationActionIcon on notification buttons, added with iOS 15

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes
-   [x] Check all targets (iOS, extension, macOS, statics) build
-   [x] Install branch via Cocoapods into empty project & verify can import SDK (only needed if adding/removing files)

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] All relevant build targets
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

Post Release:

Update docs site with correct version number references

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/ios/
- [x] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/ios/#changelog
