### PR TITLE
Expose in-app message data to KSInAppDeepLinkHandlerBlock

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -1222,7 +1222,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
@@ -1278,7 +1278,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-iOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1341,7 +1341,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
@@ -1397,7 +1397,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kumulos.KumulosSDK-macOS";
 				PRODUCT_NAME = KumulosSDK;
@@ -1670,7 +1670,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;
@@ -1716,7 +1716,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 4.7.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.dev.KumulosSDKExtension;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -791,7 +791,7 @@
 		12735B3F1E4CDCA700ED4488 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					12735B491E4CDD3100ED4488 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -1595,6 +1595,7 @@
 		B62817EB268A04C200D7B876 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = AY85FBK9Q6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1604,6 +1605,7 @@
 		B62817EC268A04C200D7B876 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = AY85FBK9Q6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1613,6 +1615,7 @@
 		B62817F8268A055E00D7B876 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = AY85FBK9Q6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1622,6 +1625,7 @@
 		B62817F9268A055E00D7B876 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = AY85FBK9Q6;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 		12659F6A1FE13C3E003C31BF /* KSAnalyticsHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 12659F691FE13C3E003C31BF /* KSAnalyticsHelper.h */; };
 		126AD08B231410B100A211B8 /* KSInAppPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 12E861DC2302C4FD009EF70B /* KSInAppPresenter.h */; };
 		126AD08C2314160D00A211B8 /* KSUserNotificationCenterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12BD21BE2306D74F00BE0D18 /* KSUserNotificationCenterDelegate.h */; };
-		126AD08D23141CA600A211B8 /* KumulosInApp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12BD21CA230D8FB200BE0D18 /* KumulosInApp.h */; };
+		126AD08D23141CA600A211B8 /* KumulosInApp.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12BD21CA230D8FB200BE0D18 /* KumulosInApp.h */; };
 		12735B931E4CDFEE00ED4488 /* KumulosSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 12735B921E4CDFEE00ED4488 /* KumulosSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		12735B961E4CE00100ED4488 /* KumulosSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 12735B921E4CDFEE00ED4488 /* KumulosSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		12735BAE1E4CE35900ED4488 /* KSAPIOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 12735B991E4CE35900ED4488 /* KSAPIOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -143,15 +143,15 @@
 		12BBE99620E3CC9600DC9916 /* Kumulos+Crash.m in Sources */ = {isa = PBXBuildFile; fileRef = 125CA7721F8BD5160008CAA4 /* Kumulos+Crash.m */; };
 		12BBE99720E3CC9600DC9916 /* Kumulos+Analytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 12577D7A1FDFF51C00218A06 /* Kumulos+Analytics.m */; };
 		12BBE99920E3CC9600DC9916 /* KumulosEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 129BC4E52062AE61005AE632 /* KumulosEvents.m */; };
-		12BBE99A20E3CCB200DC9916 /* KSAPIOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735B991E4CE35900ED4488 /* KSAPIOperation.h */; };
-		12BBE99B20E3CCB200DC9916 /* KSAPIResponse.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735B9B1E4CE35900ED4488 /* KSAPIResponse.h */; };
-		12BBE99C20E3CCB200DC9916 /* Kumulos.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735B9F1E4CE35900ED4488 /* Kumulos.h */; };
-		12BBE99D20E3CCB200DC9916 /* Kumulos+Push.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735BA21E4CE35900ED4488 /* Kumulos+Push.h */; };
-		12BBE99E20E3CCB200DC9916 /* KumulosPushSubscriptionManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735BA61E4CE35900ED4488 /* KumulosPushSubscriptionManager.h */; };
-		12BBE99F20E3CCB200DC9916 /* KumulosSDK.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12735B921E4CDFEE00ED4488 /* KumulosSDK.h */; };
-		12BBE9A020E3CCB200DC9916 /* Kumulos+Location.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 125321C21F7511F0007077AC /* Kumulos+Location.h */; };
-		12BBE9A120E3CCB200DC9916 /* Kumulos+Crash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 125CA7711F8BD5160008CAA4 /* Kumulos+Crash.h */; };
-		12BBE9A220E3CCB200DC9916 /* Kumulos+Analytics.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 12577D791FDFF51C00218A06 /* Kumulos+Analytics.h */; };
+		12BBE99A20E3CCB200DC9916 /* KSAPIOperation.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735B991E4CE35900ED4488 /* KSAPIOperation.h */; };
+		12BBE99B20E3CCB200DC9916 /* KSAPIResponse.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735B9B1E4CE35900ED4488 /* KSAPIResponse.h */; };
+		12BBE99C20E3CCB200DC9916 /* Kumulos.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735B9F1E4CE35900ED4488 /* Kumulos.h */; };
+		12BBE99D20E3CCB200DC9916 /* Kumulos+Push.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735BA21E4CE35900ED4488 /* Kumulos+Push.h */; };
+		12BBE99E20E3CCB200DC9916 /* KumulosPushSubscriptionManager.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735BA61E4CE35900ED4488 /* KumulosPushSubscriptionManager.h */; };
+		12BBE99F20E3CCB200DC9916 /* KumulosSDK.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12735B921E4CDFEE00ED4488 /* KumulosSDK.h */; };
+		12BBE9A020E3CCB200DC9916 /* Kumulos+Location.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 125321C21F7511F0007077AC /* Kumulos+Location.h */; };
+		12BBE9A120E3CCB200DC9916 /* Kumulos+Crash.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 125CA7711F8BD5160008CAA4 /* Kumulos+Crash.h */; };
+		12BBE9A220E3CCB200DC9916 /* Kumulos+Analytics.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 12577D791FDFF51C00218A06 /* Kumulos+Analytics.h */; };
 		12BBE9A420E3CD9E00DC9916 /* libKSCrashLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 12BBE9A320E3CD9E00DC9916 /* libKSCrashLib.a */; };
 		12BD21BC2306D72C00BE0D18 /* KSUserNotificationCenterDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12BD21BB2306D72C00BE0D18 /* KSUserNotificationCenterDelegate.m */; };
 		12BD21BD2306D72C00BE0D18 /* KSUserNotificationCenterDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12BD21BB2306D72C00BE0D18 /* KSUserNotificationCenterDelegate.m */; };
@@ -197,7 +197,7 @@
 		B62817B3268A034800D7B876 /* KSPendingNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B659809B25F934F3008C074D /* KSPendingNotification.m */; };
 		B62817BB268A034E00D7B876 /* KSPendingNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B659809B25F934F3008C074D /* KSPendingNotification.m */; };
 		B62817C3268A035300D7B876 /* KSPendingNotificationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B65980EE25F96CB0008C074D /* KSPendingNotificationHelper.m */; };
-		B62817DA268A03CF00D7B876 /* Kumulos+DeepLinking.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = B6EE7713255D9F8800D5B5FB /* Kumulos+DeepLinking.h */; };
+		B62817DA268A03CF00D7B876 /* Kumulos+DeepLinking.h in Copy Files */ = {isa = PBXBuildFile; fileRef = B6EE7713255D9F8800D5B5FB /* Kumulos+DeepLinking.h */; };
 		B638A49F26D3C77700450EE5 /* KSDeepLinkFingerprinter.m in Sources */ = {isa = PBXBuildFile; fileRef = B638A49E26D3C77700450EE5 /* KSDeepLinkFingerprinter.m */; };
 		B638A4A026D3C79100450EE5 /* KSDeepLinkFingerprinter.m in Sources */ = {isa = PBXBuildFile; fileRef = B638A49E26D3C77700450EE5 /* KSDeepLinkFingerprinter.m */; };
 		B638A4A226D3C7DD00450EE5 /* KSDeepLinkFingerprinter.h in Headers */ = {isa = PBXBuildFile; fileRef = B638A4A126D3C7DD00450EE5 /* KSDeepLinkFingerprinter.h */; };
@@ -259,24 +259,25 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		12BBE97F20E3CC4200DC9916 /* CopyFiles */ = {
+		12BBE97F20E3CC4200DC9916 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				B62817DA268A03CF00D7B876 /* Kumulos+DeepLinking.h in CopyFiles */,
-				126AD08D23141CA600A211B8 /* KumulosInApp.h in CopyFiles */,
-				12BBE99A20E3CCB200DC9916 /* KSAPIOperation.h in CopyFiles */,
-				12BBE99B20E3CCB200DC9916 /* KSAPIResponse.h in CopyFiles */,
-				12BBE99C20E3CCB200DC9916 /* Kumulos.h in CopyFiles */,
-				12BBE99D20E3CCB200DC9916 /* Kumulos+Push.h in CopyFiles */,
-				12BBE99E20E3CCB200DC9916 /* KumulosPushSubscriptionManager.h in CopyFiles */,
-				12BBE99F20E3CCB200DC9916 /* KumulosSDK.h in CopyFiles */,
-				12BBE9A020E3CCB200DC9916 /* Kumulos+Location.h in CopyFiles */,
-				12BBE9A120E3CCB200DC9916 /* Kumulos+Crash.h in CopyFiles */,
-				12BBE9A220E3CCB200DC9916 /* Kumulos+Analytics.h in CopyFiles */,
+				B62817DA268A03CF00D7B876 /* Kumulos+DeepLinking.h in Copy Files */,
+				126AD08D23141CA600A211B8 /* KumulosInApp.h in Copy Files */,
+				12BBE99A20E3CCB200DC9916 /* KSAPIOperation.h in Copy Files */,
+				12BBE99B20E3CCB200DC9916 /* KSAPIResponse.h in Copy Files */,
+				12BBE99C20E3CCB200DC9916 /* Kumulos.h in Copy Files */,
+				12BBE99D20E3CCB200DC9916 /* Kumulos+Push.h in Copy Files */,
+				12BBE99E20E3CCB200DC9916 /* KumulosPushSubscriptionManager.h in Copy Files */,
+				12BBE99F20E3CCB200DC9916 /* KumulosSDK.h in Copy Files */,
+				12BBE9A020E3CCB200DC9916 /* Kumulos+Location.h in Copy Files */,
+				12BBE9A120E3CCB200DC9916 /* Kumulos+Crash.h in Copy Files */,
+				12BBE9A220E3CCB200DC9916 /* Kumulos+Analytics.h in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		6F9C9E4423D5C2DB00BBEFD5 /* CopyFiles */ = {
@@ -739,7 +740,7 @@
 			buildPhases = (
 				12BBE97D20E3CC4200DC9916 /* Sources */,
 				12BBE97E20E3CC4200DC9916 /* Frameworks */,
-				12BBE97F20E3CC4200DC9916 /* CopyFiles */,
+				12BBE97F20E3CC4200DC9916 /* Copy Files */,
 			);
 			buildRules = (
 			);

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK iOS.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK macOS.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtensionCombined.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtensionCombined.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtensionStatic.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtensionStatic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKiOS.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKiOSCombined.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKiOSCombined.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KumulosSdkObjectiveC.podspec
+++ b/KumulosSdkObjectiveC.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveC"
-  s.version = "4.7.0"
+  s.version = "5.0.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/KumulosSdkObjectiveCExtension.podspec
+++ b/KumulosSdkObjectiveCExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkObjectiveCExtension"
-  s.version = "4.7.0"
+  s.version = "5.0.0"
   s.license = "MIT"
   s.summary = "Official Objective-C SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkObjectiveC"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkObjectiveC', '~> 4.7'
+pod 'KumulosSdkObjectiveC', '~> 5.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -33,7 +33,7 @@ For more information on integrating the Objective-C SDK with your project, pleas
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkObjectiveC" ~> 4.7
+github "Kumulos/KumulosSdkObjectiveC" ~> 5.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/KSInAppPresenter.h
+++ b/Sources/InApp/KSInAppPresenter.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import "../Kumulos.h"
+#import "../KumulosInApp.h"
 #import "KSInAppModels.h"
 
 @interface KSInAppPresenter : NSObject <WKScriptMessageHandler,WKNavigationDelegate>

--- a/Sources/InApp/KSInAppPresenter.h
+++ b/Sources/InApp/KSInAppPresenter.h
@@ -15,3 +15,9 @@
 - (void) queueMessagesForPresentation:(NSArray<KSInAppMessage*>* _Nonnull) messages presentingTickles:(NSOrderedSet<NSNumber*>* _Nullable)tickleIds;
 
 @end
+
+@interface KSInAppButtonPress ()
+
++ (instancetype _Nonnull) forInAppMessage:(KSInAppMessage* _Nonnull)message withDeepLink:(NSDictionary* _Nonnull)deepLinkData;
+
+@end

--- a/Sources/Kumulos+Analytics.h
+++ b/Sources/Kumulos+Analytics.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 @interface Kumulos (Analytics)
 

--- a/Sources/Kumulos+Crash.h
+++ b/Sources/Kumulos+Crash.h
@@ -5,7 +5,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 @interface Kumulos (Crash)
 

--- a/Sources/Kumulos+DeepLinking.h
+++ b/Sources/Kumulos+DeepLinking.h
@@ -5,7 +5,7 @@
 //  Created by Vladislav Voicehovics on 12/11/2020.
 //
 
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 @interface Kumulos (DeepLinking)
 + (void) scene:(UIScene* _Nonnull)scene continueUserActivity:(NSUserActivity* _Nonnull)userActivity  API_AVAILABLE(ios(13.0));

--- a/Sources/Kumulos+Location.h
+++ b/Sources/Kumulos+Location.h
@@ -6,7 +6,7 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 @interface Kumulos (Location)
 

--- a/Sources/Kumulos+Push.h
+++ b/Sources/Kumulos+Push.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 API_AVAILABLE(ios(10.0))
 typedef void (^ _Nullable KSUNAuthorizationCheckedHandler)(UNAuthorizationStatus status, NSError* _Nullable error);

--- a/Sources/Kumulos+Stats.m
+++ b/Sources/Kumulos+Stats.m
@@ -15,7 +15,7 @@
 #import "KumulosEvents.h"
 #endif
 
-static const NSString* KSSdkVersion = @"4.7.0";
+static const NSString* KSSdkVersion = @"5.0.0";
 
 @implementation Kumulos (Stats)
 

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -11,13 +11,13 @@
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 #else
 #import <UIKit/UIKit.h>
-#import "KumulosInApp.h"
 #endif
 
 @class KSAPIOperation;
 @class KSAPIResponse;
 @class KSPushNotification;
 @class KSDeepLink;
+@class KSInAppButtonPress;
 @protocol KSAPIOperationDelegate;
 
 typedef void (^ _Nullable KSAPIOperationSuccessBlock)(KSAPIResponse* _Nonnull, KSAPIOperation* _Nonnull);

--- a/Sources/Kumulos.h
+++ b/Sources/Kumulos.h
@@ -11,6 +11,7 @@
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 #else
 #import <UIKit/UIKit.h>
+#import "KumulosInApp.h"
 #endif
 
 @class KSAPIOperation;
@@ -21,7 +22,7 @@
 
 typedef void (^ _Nullable KSAPIOperationSuccessBlock)(KSAPIResponse* _Nonnull, KSAPIOperation* _Nonnull);
 typedef void (^ _Nullable KSAPIOperationFailureBlock)(NSError* _Nonnull, KSAPIOperation* _Nonnull);
-typedef void (^ _Nullable KSInAppDeepLinkHandlerBlock)(NSDictionary* _Nonnull data);
+typedef void (^ _Nullable KSInAppDeepLinkHandlerBlock)(KSInAppButtonPress* _Nonnull buttonPress);
 typedef void (^ _Nullable KSPushOpenedHandlerBlock)(KSPushNotification* _Nonnull notification);
 
 typedef NS_ENUM(NSInteger, KSDeepLinkResolution) {

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -14,6 +14,7 @@
 #if TARGET_OS_IOS
 #import "Kumulos+Push.h"
 #import "Kumulos+PushProtected.h"
+#import "InApp/KSInAppModels.h"
 #endif
 
 #ifdef COCOAPODS

--- a/Sources/Kumulos.m
+++ b/Sources/Kumulos.m
@@ -14,7 +14,6 @@
 #if TARGET_OS_IOS
 #import "Kumulos+Push.h"
 #import "Kumulos+PushProtected.h"
-#import "InApp/KSInAppModels.h"
 #endif
 
 #ifdef COCOAPODS

--- a/Sources/KumulosInApp.h
+++ b/Sources/KumulosInApp.h
@@ -38,6 +38,14 @@ typedef void (^ _Nullable InboxUpdatedHandlerBlock)(void);
 typedef void (^ _Nullable InboxSummaryBlock)(InAppInboxSummary* _Nullable inboxSummary);
 
 
+@interface KSInAppButtonPress : NSObject
+
+@property (nonatomic,strong,readonly) NSDictionary* _Nonnull deepLinkData;
+@property (nonatomic,strong,readonly) NSNumber* _Nonnull messageId;
+@property (nonatomic,strong,readonly) NSDictionary* _Nullable messageData;
+
+@end
+
 @interface KumulosInApp : NSObject
 
 /**

--- a/Sources/KumulosInApp.m
+++ b/Sources/KumulosInApp.m
@@ -79,6 +79,25 @@ int const DEFAULT_IMAGE_WIDTH = 300;
 
 @end
 
+@implementation KSInAppButtonPress
+
+@synthesize deepLinkData;
+@synthesize messageId;
+@synthesize messageData;
+
+// Note this initialiser is effectively private and declared in a category in KSInAppPresenter for use
+// where it is needed
++ (instancetype) forInAppMessage:(KSInAppMessage*)message withDeepLink:(NSDictionary*)deepLinkData {
+    KSInAppButtonPress* press = [KSInAppButtonPress new];
+    press->deepLinkData = deepLinkData;
+    press->messageId = message.id;
+    press->messageData = message.data;
+
+    return press;
+}
+
+@end
+
 @implementation KumulosInApp
 
 + (void)updateConsentForUser:(BOOL)consentGiven {

--- a/Sources/KumulosPushSubscriptionManager.h
+++ b/Sources/KumulosPushSubscriptionManager.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 /**
  * Model representing a push channel & its subscription status

--- a/Sources/KumulosSDK.h
+++ b/Sources/KumulosSDK.h
@@ -18,20 +18,20 @@ FOUNDATION_EXPORT const unsigned char KumulosSDKVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Sources/PublicHeader.h>
 
-#import "Kumulos.h"
+#import <KumulosSDK/Kumulos.h>
 
 
 #if TARGET_OS_IOS
-#import "Kumulos+DeepLinking.h"
-#import "Kumulos+Push.h"
-#import "KumulosPushSubscriptionManager.h"
-#import "Kumulos+Location.h"
-#import "Kumulos+Analytics.h"
-#import "KumulosInApp.h"
+#import <KumulosSDK/Kumulos+DeepLinking.h>
+#import <KumulosSDK/Kumulos+Push.h>
+#import <KumulosSDK/KumulosPushSubscriptionManager.h>
+#import <KumulosSDK/Kumulos+Location.h>
+#import <KumulosSDK/Kumulos+Analytics.h>
+#import <KumulosSDK/KumulosInApp.h>
 
 #endif
 
-#import "KSAPIOperation.h"
-#import "KSAPIResponse.h"
-#import "Kumulos+Crash.h"
+#import <KumulosSDK/KSAPIOperation.h>
+#import <KumulosSDK/KSAPIResponse.h>
+#import <KumulosSDK/Kumulos+Crash.h>
 


### PR DESCRIPTION
### Description of Changes

Expose in-app message data to KSInAppDeepLinkHandlerBlock:

- Port of https://github.com/Kumulos/KumulosSdkSwift/pull/80
- Update project to latest settings for Xcode 13
- Fix warnings about using double-quoted header includes in framework files

The KSInAppButtonPress class contains the original deep link button data in the deepLinkData field, and additionally offers the in-app message's ID and (optional) data field.

<img width="859" alt="Screenshot 2021-09-23 at 14 16 51" src="https://user-images.githubusercontent.com/1305158/134515193-e1389b43-3990-4cb0-8e34-934fd8a46590.png">

### Breaking Changes

- `KSInAppDeepLinkHandlerBlock` now takes `KSInAppButtonPress*` as its only argument

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes
-   [x] Check all targets (iOS, extension, macOS, statics) build
-   [ ] Install branch via Cocoapods into empty project & verify can import SDK (only needed if adding/removing files)

Bump versions in:

-   [x] `Sources/Kumulos+Stats.m`
-   [x] `KumulosSdkObjectiveC.podspec`
-   [x] `KumulosSdkObjectiveCExtension.podspec`
-   [x] All relevant build targets
-   [x] `README.md`

Release:

-   [x] Squash and merge to master
-   [x] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/ios/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/ios/#changelog
